### PR TITLE
Feature/horner

### DIFF
--- a/.github/workflows/ContinuousIntegration.yml
+++ b/.github/workflows/ContinuousIntegration.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ ubuntu-18.04, macos-10.15 ]
-        cxx: [ clang++, g++-9 ]
+        os: [ ubuntu-20.04, macos-11 ]
+        cxx: [ clang++, g++-10 ]
         build_type: [ Debug, Release ]
 
     steps:
@@ -25,17 +25,15 @@ jobs:
       run: |
         which ${{matrix.cxx}}
         ${{matrix.cxx}} --version
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: mkdir bin
       run: mkdir bin
     - name: cmake
-      run: cmake -DPYTHON_EXECUTABLE=$(which python3) -D CMAKE_CXX_COMPILER=`which ${{matrix.cxx}}` -D CMAKE_BUILD_TYPE=${{matrix.build_type}} -D codex.tests=ON ..
+      run: cmake -DPYTHON_EXECUTABLE=$(which python3) -D CMAKE_CXX_COMPILER=`which ${{matrix.cxx}}` -D CMAKE_BUILD_TYPE=${{matrix.build_type}} -D scion.tests=ON ..
       working-directory: ./bin
     - name: make
       run: make -j2
       working-directory: ./bin
     - name: ctest
-      run: |
-        cp *.so ../python
-        ctest --rerun-failed --output-on-failure -j2
+      run: ctest -j2
       working-directory: ./bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,8 @@ if( scion.python )
 
   pybind11_add_module( scion.python
       python/src/scion.python.cpp
+      python/src/math.python.cpp
+      python/src/math/horner.python.cpp
       )
 
   target_link_libraries( scion.python PRIVATE scion )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,22 +75,22 @@ if( scion.python )
       )
 
   target_link_libraries( scion.python PRIVATE scion )
-  target_include_directories( scion.python PRIVATE python/src )
+  target_include_directories( scion.python PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/python/src )
   target_compile_options( scion.python PRIVATE "-fvisibility=hidden" )
   set_target_properties( scion.python PROPERTIES OUTPUT_NAME scion )
   set_target_properties( scion.python PROPERTIES COMPILE_DEFINITIONS "PYBIND11" )
   set_target_properties( scion.python PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
+  message( STATUS "Building scion's python API" )
+
+  list( APPEND SCION_PYTHONPATH ${CMAKE_CURRENT_BINARY_DIR} )
+
+  include( cmake/unit_testing_python.cmake )
+
 endif()
 
-#######################################################################
-# Top-level Only
-#######################################################################
-
 if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
-
-    if( scion.tests )
-        include( cmake/unit_testing.cmake )
-    endif()
-
+  if( scion.tests )
+    include( cmake/unit_testing.cmake )
+  endif()
 endif()

--- a/cmake/unit_testing.cmake
+++ b/cmake/unit_testing.cmake
@@ -10,4 +10,4 @@ enable_testing()
 # Unit testing directories
 #######################################################################
 
-# add_subdirectory( src/codex/xxx/test )
+add_subdirectory( src/scion/math/horner/test )

--- a/cmake/unit_testing_python.cmake
+++ b/cmake/unit_testing_python.cmake
@@ -1,0 +1,14 @@
+#######################################################################
+# Setup
+#######################################################################
+
+enable_testing()
+
+#######################################################################
+# Python unit testing
+#######################################################################
+
+message( STATUS "Adding scion Python unit testing" )
+
+# add_test( NAME scion.python.math.horner COMMAND ${PYTHON_EXECUTABLE} -m unittest -v test/Test_scion_math_horner.py WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/python )
+# set_tests_properties( scion.python.math.horner PROPERTIES ENVIRONMENT PYTHONPATH=${SCION_PYTHONPATH}:$ENV{PYTHONPATH})

--- a/cmake/unit_testing_python.cmake
+++ b/cmake/unit_testing_python.cmake
@@ -10,5 +10,5 @@ enable_testing()
 
 message( STATUS "Adding scion Python unit testing" )
 
-# add_test( NAME scion.python.math.horner COMMAND ${PYTHON_EXECUTABLE} -m unittest -v test/Test_scion_math_horner.py WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/python )
-# set_tests_properties( scion.python.math.horner PROPERTIES ENVIRONMENT PYTHONPATH=${SCION_PYTHONPATH}:$ENV{PYTHONPATH})
+add_test( NAME scion.python.math.horner COMMAND ${PYTHON_EXECUTABLE} -m unittest -v test/math/Test_scion_math_horner.py WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/python )
+set_tests_properties( scion.python.math.horner PROPERTIES ENVIRONMENT PYTHONPATH=${SCION_PYTHONPATH}:$ENV{PYTHONPATH})

--- a/python/src/math.python.cpp
+++ b/python/src/math.python.cpp
@@ -19,7 +19,7 @@ void wrapMathModule( python::module& module ) {
   python::module submodule = module.def_submodule(
 
     "math",
-    "Common math components"
+    "Common math capabilities and components"
   );
 
   // wrap scion's math capabilities

--- a/python/src/math.python.cpp
+++ b/python/src/math.python.cpp
@@ -1,0 +1,27 @@
+// system includes
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+// local includes
+
+// namespace aliases
+namespace python = pybind11;
+
+// declarations
+namespace math {
+
+  void wrapHorner( python::module& );
+}
+
+void wrapMathModule( python::module& module ) {
+
+  // create the submodule
+  python::module submodule = module.def_submodule(
+
+    "math",
+    "Common math components"
+  );
+
+  // wrap scion's math capabilities
+  math::wrapHorner( submodule );
+}

--- a/python/src/math/horner.python.cpp
+++ b/python/src/math/horner.python.cpp
@@ -1,0 +1,45 @@
+// system includes
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <vector>
+
+// local includes
+#include "scion/math/horner.hpp"
+
+// namespace aliases
+namespace python = pybind11;
+
+namespace math {
+
+template < typename X, typename Y, typename Range >
+void wrapHornerFor( python::module& module ) {
+
+  module.def(
+
+    "horner",
+    [] ( const Range& coefficients, const X& x ) -> Y
+       { return njoy::scion::math::horner< X, Y, Range >( coefficients, x ); },
+    python::arg( "coefficients" ), python::arg( "x" ),
+    "Horner evaluation of a polynomial function for different x and y types "
+    "using a list or range\n\n"
+    "A polynomial is defined as a sequence of coefficients c_i so that the\n"
+    "polynomial of order n is given by:\n\n"
+    "  y = c_n * x^n + c_(n - 1) * x^(n - 1) + c_(n - 2) * x^(n - 2) + ...\n\n"
+    "With the Horner scheme, a polynomial is evaluated as follows:\n\n"
+    "  y = c_n * (x + c_(n-1) * (x + c_(n - 2) * (x + ...\n\n"
+    "The main reason for using the Horner scheme is computational efficiency.\n\n"
+    "Source: Numerical recipes - Third edition, p201-202\n\n"
+    " Arguments:\n"
+    "     coefficients   a list of coefficient values (from lowest to highest\n"
+    "                    order coefficient)\n"
+    "     x              the value at which the polynomial must be evaluated"
+  );
+}
+
+void wrapHorner( python::module& module ) {
+
+  // wrap the horner functions we need
+  wrapHornerFor< double, double, std::vector< double > >( module );
+}
+
+} // namespace math

--- a/python/src/scion.python.cpp
+++ b/python/src/scion.python.cpp
@@ -7,6 +7,9 @@
 // namespace aliases
 namespace python = pybind11;
 
+// declarations
+void wrapMathModule( python::module& );
+
 /**
  *  @brief scion python bindings
  *
@@ -15,4 +18,6 @@ namespace python = pybind11;
  */
 PYBIND11_MODULE( scion, module ) {
 
+  // wrap the math submodule
+  wrapMathModule( module );
 }

--- a/python/test/__init__.py
+++ b/python/test/__init__.py
@@ -1,0 +1,1 @@
+# empty __init__.py

--- a/python/test/math/Test_scion_math_horner.py
+++ b/python/test/math/Test_scion_math_horner.py
@@ -1,0 +1,37 @@
+# standard imports
+import unittest
+
+# third party imports
+
+# local imports
+from scion.math import horner
+
+class Test_scion_math_horner( unittest.TestCase ) :
+    """Unit test for the horner function."""
+
+    def test_horner( self ) :
+
+        # polynomial coefficients (from lower order to higher order)
+        order0 = [ 1. ]
+        order1 = [ 1., 2. ]
+        order2 = [ 1., 2., 3. ]
+        order3 = [ 1., 2., 3., 4. ]
+
+        self.assertAlmostEqual(  1., horner( order0, 0. ) )
+        self.assertAlmostEqual(  1., horner( order1, 0. ) )
+        self.assertAlmostEqual(  1., horner( order2, 0. ) )
+        self.assertAlmostEqual(  1., horner( order3, 0. ) )
+
+        self.assertAlmostEqual(  1., horner( order0, 1. ) )
+        self.assertAlmostEqual(  3., horner( order1, 1. ) )
+        self.assertAlmostEqual(  6., horner( order2, 1. ) )
+        self.assertAlmostEqual( 10., horner( order3, 1. ) )
+
+        self.assertAlmostEqual(  1., horner( order0, -1. ) )
+        self.assertAlmostEqual( -1., horner( order1, -1. ) )
+        self.assertAlmostEqual(  2., horner( order2, -1. ) )
+        self.assertAlmostEqual( -2., horner( order3, -1. ) )
+
+if __name__ == '__main__' :
+
+    unittest.main()

--- a/python/test/math/__init__.py
+++ b/python/test/math/__init__.py
@@ -1,0 +1,1 @@
+# empty __init__.py

--- a/src/scion/math/horner.hpp
+++ b/src/scion/math/horner.hpp
@@ -63,8 +63,8 @@ Y horner( Iter first, Iter last, const X& x ) noexcept {
  *
  *  Source: Numerical recipes - Third edition, p201-202
  *
- *  @param[in] coefficients   a range of coefficient values (lowest order should
- *                            be given first)
+ *  @param[in] coefficients   a range of coefficient values (from lowest to
+ *                            highest order coefficient)
  *  @param[in] x              the value of X
  *
  *  @return The evaluated Y value

--- a/src/scion/math/horner.hpp
+++ b/src/scion/math/horner.hpp
@@ -1,0 +1,54 @@
+#ifndef NJOY_SCION_MATH_HORNER
+#define NJOY_SCION_MATH_HORNER
+
+// system includes
+
+// other includes
+
+namespace njoy {
+namespace scion {
+namespace math {
+
+/** @brief Horner evaluation of a polynomial function for different x and y
+ *         types using iterators
+ *
+ *  A polynomial is defined as a sequence of coefficients c_i so that the
+ *  polynomial of order n is given by:
+ *
+ *    y = c_n * x^n + c_(n - 1) * x^(n - 1) + c_(n - 2) * x^(n - 2) + ...
+ *
+ *  With the Horner scheme, a polynomial is evaluated as follows:
+ *
+ *    y = c_n * (x + c_(n-1) * (x + c_(n - 2) * (x + ...
+ *
+ *  The main reason for using the Horner scheme is computational efficiency.
+ *
+ *  Source: Numerical recipes - Third edition, p201-202
+ *
+ *  Note: iterator order is not tested in this function.
+ *
+ *  @param[in] first   an input iterator to the initial position in a sequence
+ *                     (must be the highest order coefficient)
+ *  @param[in] last    an input iterator to the final position in a sequence
+ *  @param[in] x       the value of X
+ *
+ *  @return The evaluated Y value
+ */
+template < typename X, typename Y = X, typename Iter >
+Y horner( Iter first, Iter last, const X& x ) noexcept {
+
+  Y y = *first;
+  ++first;
+  for (; first != last; ++first) {
+
+    y *= x;
+    y += *first;
+  }
+  return y;
+}
+
+} // math namespace
+} // scion namespace
+} // njoy namespace
+
+#endif

--- a/src/scion/math/horner.hpp
+++ b/src/scion/math/horner.hpp
@@ -47,6 +47,34 @@ Y horner( Iter first, Iter last, const X& x ) noexcept {
   return y;
 }
 
+/** @brief Horner evaluation of a polynomial function for different x and y
+ *         types using a range
+ *
+ *  A polynomial is defined as a sequence of coefficients c_i so that the
+ *  polynomial of order n is given by:
+ *
+ *    y = c_n * x^n + c_(n - 1) * x^(n - 1) + c_(n - 2) * x^(n - 2) + ...
+ *
+ *  With the Horner scheme, a polynomial is evaluated as follows:
+ *
+ *    y = c_n * (x + c_(n-1) * (x + c_(n - 2) * (x + ...
+ *
+ *  The main reason for using the Horner scheme is computational efficiency.
+ *
+ *  Source: Numerical recipes - Third edition, p201-202
+ *
+ *  @param[in] coefficients   a range of coefficient values (lowest order should
+ *                            be given first)
+ *  @param[in] x              the value of X
+ *
+ *  @return The evaluated Y value
+ */
+template < typename X, typename Y = X, typename Range >
+Y horner( const Range& coefficients, const X& x ) noexcept {
+
+  return horner( std::rbegin( coefficients ), std::rend( coefficients ), x );
+}
+
 } // math namespace
 } // scion namespace
 } // njoy namespace

--- a/src/scion/math/horner/test/CMakeLists.txt
+++ b/src/scion/math/horner/test/CMakeLists.txt
@@ -1,0 +1,18 @@
+
+add_executable( scion.math.horner.test horner.test.cpp )
+target_compile_options( scion.math.horner.test PRIVATE ${${PREFIX}_common_flags}
+$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
+${${PREFIX}_DEBUG_flags}
+$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
+$<$<CONFIG:RELEASE>:
+${${PREFIX}_RELEASE_flags}
+$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
+$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
+
+${CXX_appended_flags} ${scion_appended_flags} )
+target_link_libraries( scion.math.horner.test PUBLIC scion )
+file( GLOB resources "resources/*" )
+foreach( resource ${resources})
+    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
+endforeach()
+add_test( NAME scion.math.horner COMMAND scion.math.horner.test )

--- a/src/scion/math/horner/test/horner.test.cpp
+++ b/src/scion/math/horner/test/horner.test.cpp
@@ -1,0 +1,63 @@
+#define CATCH_CONFIG_MAIN
+
+#include "catch.hpp"
+#include "scion/math/horner.hpp"
+
+// other includes
+
+// convenience typedefs
+using namespace njoy::scion;
+
+SCENARIO( "horner" ) {
+
+  GIVEN( "valid data for a polynomial" ) {
+
+    // polynomial coefficients (from lower order to higher order)
+    std::vector< double > order0 = { 1. };
+    std::vector< double > order1 = { 1., 2. };
+    std::vector< double > order2 = { 1., 2., 3. };
+    std::vector< double > order3 = { 1., 2., 3., 4. };
+
+    WHEN( "the iterators are used" ) {
+
+      THEN( "the polynomials can be evaluated" ) {
+
+        CHECK(  1. == Approx( math::horner( order0.rbegin(), order0.rend(), 0. ) ) );
+        CHECK(  1. == Approx( math::horner( order1.rbegin(), order1.rend(), 0. ) ) );
+        CHECK(  1. == Approx( math::horner( order2.rbegin(), order2.rend(), 0. ) ) );
+        CHECK(  1. == Approx( math::horner( order3.rbegin(), order3.rend(), 0. ) ) );
+
+        CHECK(  1. == Approx( math::horner( order0.rbegin(), order0.rend(), 1. ) ) );
+        CHECK(  3. == Approx( math::horner( order1.rbegin(), order1.rend(), 1. ) ) );
+        CHECK(  6. == Approx( math::horner( order2.rbegin(), order2.rend(), 1. ) ) );
+        CHECK( 10. == Approx( math::horner( order3.rbegin(), order3.rend(), 1. ) ) );
+
+        CHECK(  1. == Approx( math::horner( order0.rbegin(), order0.rend(), -1. ) ) );
+        CHECK( -1. == Approx( math::horner( order1.rbegin(), order1.rend(), -1. ) ) );
+        CHECK(  2. == Approx( math::horner( order2.rbegin(), order2.rend(), -1. ) ) );
+        CHECK( -2. == Approx( math::horner( order3.rbegin(), order3.rend(), -1. ) ) );
+      } // THEN
+    } // WHEN
+
+    WHEN( "the vectors are used" ) {
+
+      THEN( "the polynomials can be evaluated" ) {
+
+        CHECK(  1. == Approx( math::horner( order0, 0. ) ) );
+        CHECK(  1. == Approx( math::horner( order1, 0. ) ) );
+        CHECK(  1. == Approx( math::horner( order2, 0. ) ) );
+        CHECK(  1. == Approx( math::horner( order3, 0. ) ) );
+
+        CHECK(  1. == Approx( math::horner( order0, 1. ) ) );
+        CHECK(  3. == Approx( math::horner( order1, 1. ) ) );
+        CHECK(  6. == Approx( math::horner( order2, 1. ) ) );
+        CHECK( 10. == Approx( math::horner( order3, 1. ) ) );
+
+        CHECK(  1. == Approx( math::horner( order0, -1. ) ) );
+        CHECK( -1. == Approx( math::horner( order1, -1. ) ) );
+        CHECK(  2. == Approx( math::horner( order2, -1. ) ) );
+        CHECK( -2. == Approx( math::horner( order3, -1. ) ) );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+} // SCENARIO


### PR DESCRIPTION
This PR updates the build system to the same level as ACEtk and ENDFtk and adds a first scion capability.

As a first capability in scion, the horner scheme was ported from resonance reconstruction. The existing horner capability was extended to include an additional horner function that takes a range instead of iterators (this new function uses the iterator version under the hood). Because of inlining of template code, the compiler will optimise the function calls.

Python bindings have been enabled as well. For the horner scheme, only the function using doubles and std::vector<double> as the range have been bound (I don't think using the iterator version will contribute anything there). A templated wrapper function for horner is provided to bind additional versions of the horner function (e.g. using std::complex<double> and std::vector<std::complex<double>>) whenever the need would arise.