### PR TITLE
Feature/legendre

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ if( scion.python )
       python/src/scion.python.cpp
       python/src/math.python.cpp
       python/src/math/horner.python.cpp
+      python/src/math/legendre.python.cpp
       )
 
   target_link_libraries( scion.python PRIVATE scion )

--- a/cmake/unit_testing.cmake
+++ b/cmake/unit_testing.cmake
@@ -12,3 +12,4 @@ enable_testing()
 
 add_subdirectory( src/scion/math/clenshaw/test )
 add_subdirectory( src/scion/math/horner/test )
+add_subdirectory( src/scion/math/legendre/test )

--- a/cmake/unit_testing_python.cmake
+++ b/cmake/unit_testing_python.cmake
@@ -12,3 +12,6 @@ message( STATUS "Adding scion Python unit testing" )
 
 add_test( NAME scion.python.math.horner COMMAND ${PYTHON_EXECUTABLE} -m unittest -v test/math/Test_scion_math_horner.py WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/python )
 set_tests_properties( scion.python.math.horner PROPERTIES ENVIRONMENT PYTHONPATH=${SCION_PYTHONPATH}:$ENV{PYTHONPATH})
+
+add_test( NAME scion.python.math.legendre COMMAND ${PYTHON_EXECUTABLE} -m unittest -v test/math/Test_scion_math_legendre.py WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/python )
+set_tests_properties( scion.python.math.legendre PROPERTIES ENVIRONMENT PYTHONPATH=${SCION_PYTHONPATH}:$ENV{PYTHONPATH})

--- a/python/src/math.python.cpp
+++ b/python/src/math.python.cpp
@@ -11,6 +11,7 @@ namespace python = pybind11;
 namespace math {
 
   void wrapHorner( python::module& );
+  void wrapLegendre( python::module& );
 }
 
 void wrapMathModule( python::module& module ) {
@@ -24,4 +25,5 @@ void wrapMathModule( python::module& module ) {
 
   // wrap scion's math capabilities
   math::wrapHorner( submodule );
+  math::wrapLegendre( submodule );
 }

--- a/python/src/math/legendre.python.cpp
+++ b/python/src/math/legendre.python.cpp
@@ -1,0 +1,35 @@
+// system includes
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+// local includes
+#include "scion/math/legendre.hpp"
+
+// namespace aliases
+namespace python = pybind11;
+
+namespace math {
+
+template < typename X, typename Y = X >
+void wrapLegendreFor( python::module& module ) {
+
+  module.def(
+
+    "legendre",
+    [] ( unsigned int n, const X& x ) -> Y
+       { return njoy::scion::math::legendre( n, x ); },
+    python::arg( "order" ), python::arg( "x" ),
+    "Evaluate a Legendre polynomial of order n\n\n"
+    " Arguments:\n"
+    "     order    the degree of the Legendre polynomial\n"
+    "     x        the value at which the polynomial must be evaluated"
+  );
+}
+
+void wrapLegendre( python::module& module ) {
+
+  // wrap the legendre functions we need
+  wrapLegendreFor< double >( module );
+}
+
+} // namespace math

--- a/python/test/math/Test_scion_math_legendre.py
+++ b/python/test/math/Test_scion_math_legendre.py
@@ -1,0 +1,40 @@
+# standard imports
+import unittest
+
+# third party imports
+
+# local imports
+from scion.math import legendre
+
+class Test_scion_math_horner( unittest.TestCase ) :
+    """Unit test for the horner function."""
+
+    def test_legendre( self ) :
+
+        self.assertAlmostEqual(  1.0   , legendre( 0, -1.0 ) )
+        self.assertAlmostEqual(  1.0   , legendre( 0, -0.5 ) )
+        self.assertAlmostEqual(  1.0   , legendre( 0,  0.0 ) )
+        self.assertAlmostEqual(  1.0   , legendre( 0,  0.5 ) )
+        self.assertAlmostEqual(  1.0   , legendre( 0,  1.0 ) )
+
+        self.assertAlmostEqual( -1.0   , legendre( 1, -1.0 ) )
+        self.assertAlmostEqual( -0.5   , legendre( 1, -0.5 ) )
+        self.assertAlmostEqual(  0.0   , legendre( 1,  0.0 ) )
+        self.assertAlmostEqual(  0.5   , legendre( 1,  0.5 ) )
+        self.assertAlmostEqual(  1.0   , legendre( 1,  1.0 ) )
+
+        self.assertAlmostEqual(  1.0   , legendre( 2, -1.0 ) )
+        self.assertAlmostEqual( -0.125 , legendre( 2, -0.5 ) )
+        self.assertAlmostEqual( -0.5   , legendre( 2,  0.0 ) )
+        self.assertAlmostEqual( -0.125 , legendre( 2,  0.5 ) )
+        self.assertAlmostEqual(  1.0   , legendre( 2,  1.0 ) )
+
+        self.assertAlmostEqual( -1.0   , legendre( 3, -1.0 ) )
+        self.assertAlmostEqual(  0.4375, legendre( 3, -0.5 ) )
+        self.assertAlmostEqual(  0.0   , legendre( 3,  0.0 ) )
+        self.assertAlmostEqual( -0.4375, legendre( 3,  0.5 ) )
+        self.assertAlmostEqual(  1.0   , legendre( 3,  1.0 ) )
+
+if __name__ == '__main__' :
+
+    unittest.main()

--- a/src/scion/math.hpp
+++ b/src/scion/math.hpp
@@ -1,2 +1,3 @@
 #include "scion/math/clenshaw.hpp"
 #include "scion/math/horner.hpp"
+#include "scion/math/legendre.hpp"

--- a/src/scion/math/clenshaw/test/clenshaw.test.cpp
+++ b/src/scion/math/clenshaw/test/clenshaw.test.cpp
@@ -54,10 +54,14 @@ SCENARIO( "clenshaw" ) {
     std::vector< double > order2 = { 1., 2., 3. };
     std::vector< double > order3 = { 1., 2., 3., 4. };
 
-    auto a = [] ( unsigned int k, double x ) -> double
-                { return ( 2. * static_cast< double >( k ) + 1. ) * x / ( static_cast< double >( k ) + 1. ); };
-    auto b = [] ( unsigned int k, double x ) -> double
-                { return - static_cast< double >( k ) / ( static_cast< double >( k ) + 1. ); };
+    auto a = [] ( unsigned int k, double x ) -> double {
+
+      return static_cast< double >( 2 * k + 1 ) / static_cast< double >( k + 1 ) * x;
+    };
+    auto b = [] ( unsigned int k, double x ) -> double {
+
+      return - static_cast< double >( k ) / static_cast< double >( k + 1 );
+    };
 
     WHEN( "the iterators are used" ) {
 

--- a/src/scion/math/legendre.hpp
+++ b/src/scion/math/legendre.hpp
@@ -1,0 +1,51 @@
+#ifndef NJOY_SCION_MATH_LEGENDRE
+#define NJOY_SCION_MATH_LEGENDRE
+
+// system includes
+
+// other includes
+#include "Log.hpp"
+
+namespace njoy {
+namespace scion {
+namespace math {
+
+/** @brief Evaluate a Legendre polynomial of order n
+ *
+ *  @param[in] n    the degree of the Legendre polynomial
+ *  @param[in] x    the value of X
+ */
+template < typename X, typename Y = X >
+Y legendre( unsigned int n, const X& x ) {
+
+  if ( ( x < -1 ) || ( x > 1 ) ) {
+
+    Log::error( "Legendre polynomials are defined for x values in the [-1,1] interval" );
+    Log::info( "The value of x requested: {}", x );
+    throw std::exception();
+  }
+
+  Y p0 = Y( 1. );
+  Y p = Y( x );
+
+  if ( n == 0 ) {
+
+    return p0;
+  }
+
+  unsigned int l = 1;
+  while ( l < n ) {
+
+    std::swap( p0, p );
+    p = ( static_cast< Y >( 2 * l + 1 ) * x * p0 - l * p ) / static_cast< Y >( l + 1 );
+    ++l;
+  }
+
+  return p;
+}
+
+} // math namespace
+} // scion namespace
+} // njoy namespace
+
+#endif

--- a/src/scion/math/legendre/test/CMakeLists.txt
+++ b/src/scion/math/legendre/test/CMakeLists.txt
@@ -1,0 +1,18 @@
+
+add_executable( scion.math.legendre.test legendre.test.cpp )
+target_compile_options( scion.math.legendre.test PRIVATE ${${PREFIX}_common_flags}
+$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
+${${PREFIX}_DEBUG_flags}
+$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
+$<$<CONFIG:RELEASE>:
+${${PREFIX}_RELEASE_flags}
+$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
+$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
+
+${CXX_appended_flags} ${scion_appended_flags} )
+target_link_libraries( scion.math.legendre.test PUBLIC scion )
+file( GLOB resources "resources/*" )
+foreach( resource ${resources})
+    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
+endforeach()
+add_test( NAME scion.math.legendre COMMAND scion.math.legendre.test )

--- a/src/scion/math/legendre/test/legendre.test.cpp
+++ b/src/scion/math/legendre/test/legendre.test.cpp
@@ -1,0 +1,58 @@
+#define CATCH_CONFIG_MAIN
+
+#include "catch.hpp"
+#include "scion/math/legendre.hpp"
+
+// other includes
+
+// convenience typedefs
+using namespace njoy::scion;
+
+SCENARIO( "legendre" ) {
+
+  GIVEN( "valid values for x" ) {
+
+    std::vector< double > x = { -1.0, -0.5, 0.0, 0.5, 1.0 };
+
+    WHEN( "calculating the value of a Legendre polynomial of order n" ) {
+
+      THEN( "the Legendre polynomial can be evaluated" ) {
+
+        CHECK(  1.0    == Approx( math::legendre( 0, -1.0 ) ) );
+        CHECK(  1.0    == Approx( math::legendre( 0, -0.5 ) ) );
+        CHECK(  1.0    == Approx( math::legendre( 0,  0.0 ) ) );
+        CHECK(  1.0    == Approx( math::legendre( 0,  0.5 ) ) );
+        CHECK(  1.0    == Approx( math::legendre( 0,  1.0 ) ) );
+
+        CHECK( -1.0    == Approx( math::legendre( 1, -1.0 ) ) );
+        CHECK( -0.5    == Approx( math::legendre( 1, -0.5 ) ) );
+        CHECK(  0.0    == Approx( math::legendre( 1,  0.0 ) ) );
+        CHECK(  0.5    == Approx( math::legendre( 1,  0.5 ) ) );
+        CHECK(  1.0    == Approx( math::legendre( 1,  1.0 ) ) );
+
+        CHECK(  1.0    == Approx( math::legendre( 2, -1.0 ) ) );
+        CHECK( -0.125  == Approx( math::legendre( 2, -0.5 ) ) );
+        CHECK( -0.5    == Approx( math::legendre( 2,  0.0 ) ) );
+        CHECK( -0.125  == Approx( math::legendre( 2,  0.5 ) ) );
+        CHECK(  1.0    == Approx( math::legendre( 2,  1.0 ) ) );
+
+        CHECK( -1.0    == Approx( math::legendre( 3, -1.0 ) ) );
+        CHECK(  0.4375 == Approx( math::legendre( 3, -0.5 ) ) );
+        CHECK(  0.0    == Approx( math::legendre( 3,  0.0 ) ) );
+        CHECK( -0.4375 == Approx( math::legendre( 3,  0.5 ) ) );
+        CHECK(  1.0    == Approx( math::legendre( 3,  1.0 ) ) );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+
+  GIVEN( "invalid values for x" ) {
+
+    WHEN( "calculating the value of a Legendre polynomial of order n" ) {
+
+      THEN( "an exception is thrown" ) {
+
+        CHECK_THROWS( math::legendre( 0, 100. ) );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+} // SCENARIO


### PR DESCRIPTION
Implementation of a legendre function that has the same signature as std::legendre(unsigned int, double). We need these since the cmath special functions that were added in C++-17 are absent on Mac systems. Sigh.