### PR TITLE
Adding the LinearLinearTable, python bindings and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ if( scion.python )
       python/src/math/legendre.python.cpp
       python/src/math/IntervalDomain.python.cpp
       python/src/math/OpenDomain.python.cpp
+      python/src/math/LinearLinearTable.python.cpp
       python/src/math/LegendreSeries.python.cpp
       python/src/math/PolynomialSeries.python.cpp
       )

--- a/cmake/unit_testing.cmake
+++ b/cmake/unit_testing.cmake
@@ -29,5 +29,6 @@ add_subdirectory( src/scion/math/newton/test )
 
 add_subdirectory( src/scion/math/IntervalDomain/test )
 add_subdirectory( src/scion/math/OpenDomain/test )
+add_subdirectory( src/scion/math/LinearLinearTable/test )
 add_subdirectory( src/scion/math/LegendreSeries/test )
 add_subdirectory( src/scion/math/PolynomialSeries/test )

--- a/cmake/unit_testing_python.cmake
+++ b/cmake/unit_testing_python.cmake
@@ -40,6 +40,8 @@ set_tests_properties( scion.python.math.IntervalDomain PROPERTIES ENVIRONMENT PY
 add_test( NAME scion.python.math.OpenDomain COMMAND ${PYTHON_EXECUTABLE} -m unittest -v test/math/Test_scion_math_OpenDomain.py WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/python )
 set_tests_properties( scion.python.math.OpenDomain PROPERTIES ENVIRONMENT PYTHONPATH=${SCION_PYTHONPATH}:$ENV{PYTHONPATH})
 
+add_test( NAME scion.python.math.LinearLinearTable COMMAND ${PYTHON_EXECUTABLE} -m unittest -v test/math/Test_scion_math_LinearLinearTable.py WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/python )
+set_tests_properties( scion.python.math.LinearLinearTable PROPERTIES ENVIRONMENT PYTHONPATH=${SCION_PYTHONPATH}:$ENV{PYTHONPATH})
 add_test( NAME scion.python.math.LegendreSeries COMMAND ${PYTHON_EXECUTABLE} -m unittest -v test/math/Test_scion_math_LegendreSeries.py WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/python )
 set_tests_properties( scion.python.math.LegendreSeries PROPERTIES ENVIRONMENT PYTHONPATH=${SCION_PYTHONPATH}:$ENV{PYTHONPATH})
 add_test( NAME scion.python.math.PolynomialSeries COMMAND ${PYTHON_EXECUTABLE} -m unittest -v test/math/Test_scion_math_PolynomialSeries.py WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/python )

--- a/python/src/math.python.cpp
+++ b/python/src/math.python.cpp
@@ -24,6 +24,7 @@ namespace math {
   void wrapOpenDomain( python::module& );
 
   // functions
+  void wrapLinearLinearTable( python::module& );
   void wrapLegendreSeries( python::module& );
   void wrapPolynomialSeries( python::module& );
 }
@@ -43,6 +44,7 @@ void wrapMathModule( python::module& module ) {
   math::wrapLegendre( submodule );
   math::wrapIntervalDomain( submodule );
   math::wrapOpenDomain( submodule );
+  math::wrapLinearLinearTable( submodule );
   math::wrapLegendreSeries( submodule );
   math::wrapPolynomialSeries( submodule );
 }

--- a/python/src/math/LinearLinearTable.python.cpp
+++ b/python/src/math/LinearLinearTable.python.cpp
@@ -1,0 +1,64 @@
+// system includes
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+// local includes
+#include "scion/math/LinearLinearTable.hpp"
+#include "definitions.hpp"
+
+// namespace aliases
+namespace python = pybind11;
+
+namespace math {
+
+template < typename X, typename Y = X >
+void wrapLinearLinearTableFor( python::module& module, const std::string& name ) {
+
+  // type aliases
+  using Component = njoy::scion::math::LinearLinearTable< X, Y >;
+
+  // wrap views created by this component
+
+  // create the component
+  python::class_< Component > component(
+
+    module,
+    name.c_str(),
+    "Tabulated data with linear-linear interpolation"
+  );
+
+  // wrap the component
+  component
+  .def(
+
+    python::init< std::vector< X >, std::vector< Y > >(),
+    python::arg( "x" ), python::arg( "y" ),
+    "Initialise the function with an open domain\n\n"
+    "Arguments:\n"
+    "    self   the function\n"
+    "    x      the x values of the tabulated data\n"
+    "    y      the y values of the tabulated data"
+  )
+  .def_property_readonly(
+
+    "x",
+    &Component::x,
+    "The x values of the table"
+  )
+  .def_property_readonly(
+
+    "y",
+    &Component::y,
+    "The y values of the table"
+  );
+
+  // add standard function definitions
+  addStandardFunctionDefinitions< Component, X, Y >( component );
+}
+
+void wrapLinearLinearTable( python::module& module ) {
+
+  wrapLinearLinearTableFor< double >( module, "LinearLinearTable" );
+}
+
+} // namespace math

--- a/python/test/math/Test_scion_math_LinearLinearTable.py
+++ b/python/test/math/Test_scion_math_LinearLinearTable.py
@@ -1,0 +1,77 @@
+# standard imports
+import unittest
+import sys
+
+# third party imports
+
+# local imports
+from scion.math import LinearLinearTable
+from scion.math import IntervalDomain
+
+class Test_scion_math_LinearLinearTable( unittest.TestCase ) :
+    """Unit test for the LinearLinearTable class."""
+
+    def test_component( self ) :
+
+        def verify_chunk( self, chunk ) :
+
+            # verify content
+           self.assertEqual( 4, len( chunk.x ) )
+           self.assertEqual( 4, len( chunk.y ) )
+           self.assertAlmostEqual( 1., chunk.x[0] )
+           self.assertAlmostEqual( 2., chunk.x[1] )
+           self.assertAlmostEqual( 3., chunk.x[2] )
+           self.assertAlmostEqual( 4., chunk.x[3] )
+           self.assertAlmostEqual( 4., chunk.y[0] )
+           self.assertAlmostEqual( 3., chunk.y[1] )
+           self.assertAlmostEqual( 2., chunk.y[2] )
+           self.assertAlmostEqual( 1., chunk.y[3] )
+
+            # verify evaluation - values of x in the x grid
+            self.assertAlmostEqual( 4., chunk.evaluate( x = 1. ) )
+            self.assertAlmostEqual( 3., chunk.evaluate( x = 2. ) )
+            self.assertAlmostEqual( 2., chunk.evaluate( x = 3. ) )
+            self.assertAlmostEqual( 1., chunk.evaluate( x = 4. ) )
+
+            # verify evaluation - values of x outside the x grid
+            self.assertAlmostEqual( 0.0, chunk( x = 0. ) )
+            self.assertAlmostEqual( 0.0, chunk( x = 5. ) )
+
+            # verify evaluation - values of x inside the x grid
+            self.assertAlmostEqual( 3.5, chunk( x = 1.5 ) )
+            self.assertAlmostEqual( 1.5, chunk( x = 3.5 ) )
+
+        # the data is given explicitly
+        chunk = LinearLinearTable( x = [ 1., 2., 3., 4. ],
+                                   y = [ 4., 3., 2., 1. ] )
+
+        verify_chunk( self, chunk )
+
+    def test_failures( self ) :
+
+        print( '\n' )
+
+        # there are not enough values in the x or y grid
+        with self.assertRaises( Exception ) :
+
+            chunk = LinearLinearTable( x = [], y = [] )
+
+        with self.assertRaises( Exception ) :
+
+            chunk = LinearLinearTable( x = [ 1. ], y = [ 4. ] )
+
+        # the x and y grid do not have the same number of points
+        with self.assertRaises( Exception ) :
+
+            chunk = LinearLinearTable( x = [ 1., 2., 3., 4. ],
+                                       y = [ 4., 3., 2. ] )
+
+        # the x grid is not sorted
+        with self.assertRaises( Exception ) :
+
+            chunk = LinearLinearTable( x = [ 1., 3., 2., 4. ],
+                                       y = [ 4., 3., 2., 1. ] )
+
+if __name__ == '__main__' :
+
+    unittest.main()

--- a/python/test/math/Test_scion_math_LinearLinearTable.py
+++ b/python/test/math/Test_scion_math_LinearLinearTable.py
@@ -16,16 +16,16 @@ class Test_scion_math_LinearLinearTable( unittest.TestCase ) :
         def verify_chunk( self, chunk ) :
 
             # verify content
-           self.assertEqual( 4, len( chunk.x ) )
-           self.assertEqual( 4, len( chunk.y ) )
-           self.assertAlmostEqual( 1., chunk.x[0] )
-           self.assertAlmostEqual( 2., chunk.x[1] )
-           self.assertAlmostEqual( 3., chunk.x[2] )
-           self.assertAlmostEqual( 4., chunk.x[3] )
-           self.assertAlmostEqual( 4., chunk.y[0] )
-           self.assertAlmostEqual( 3., chunk.y[1] )
-           self.assertAlmostEqual( 2., chunk.y[2] )
-           self.assertAlmostEqual( 1., chunk.y[3] )
+            self.assertEqual( 4, len( chunk.x ) )
+            self.assertEqual( 4, len( chunk.y ) )
+            self.assertAlmostEqual( 1., chunk.x[0] )
+            self.assertAlmostEqual( 2., chunk.x[1] )
+            self.assertAlmostEqual( 3., chunk.x[2] )
+            self.assertAlmostEqual( 4., chunk.x[3] )
+            self.assertAlmostEqual( 4., chunk.y[0] )
+            self.assertAlmostEqual( 3., chunk.y[1] )
+            self.assertAlmostEqual( 2., chunk.y[2] )
+            self.assertAlmostEqual( 1., chunk.y[3] )
 
             # verify evaluation - values of x in the x grid
             self.assertAlmostEqual( 4., chunk.evaluate( x = 1. ) )

--- a/src/scion/math/LinearLinearTable.hpp
+++ b/src/scion/math/LinearLinearTable.hpp
@@ -1,0 +1,76 @@
+#ifndef NJOY_SCION_MATH_LINEARLINEARTABLE
+#define NJOY_SCION_MATH_LINEARLINEARTABLE
+
+// system includes
+#include <vector>
+
+// other includes
+#include "scion/interpolation/LinearLinear.hpp"
+#include "scion/interpolation/Table.hpp"
+#include "scion/math/FunctionBase.hpp"
+
+namespace njoy {
+namespace scion {
+namespace math {
+
+  /**
+   *  @class
+   *  @brief Tabulated data with linear-linear interpolation
+   */
+  template < typename X, typename Y = X >
+  class LinearLinearTable : public FunctionBase< LinearLinearTable< X, Y >, X, Y > {
+
+    /* type aliases */
+    using Parent = FunctionBase< LinearLinearTable< X, Y >, X, Y >;
+
+    /* fields */
+    interpolation::Table< interpolation::LinearLinear,
+                          std::vector< X >,
+                          std::vector< Y > > table_;
+
+    /* auxiliary function */
+
+  public:
+
+    /* constructor */
+    #include "scion/math/LinearLinearTable/src/ctor.hpp"
+
+    /* methods */
+
+    /**
+     *  @brief Return the x values of the table
+     */
+    const std::vector< X >& x() const noexcept {
+
+      return this->table_.x();
+    }
+
+    /**
+     *  @brief Return the y values of the table
+     */
+    const std::vector< Y >& y() const noexcept {
+
+      return this->table_.y();
+    }
+
+    /**
+     *  @brief Evaluate the function for a value of x
+     *
+     *  @param x   the value to be evaluated
+     */
+    Y evaluate( const X& x ) const {
+
+      return this->table_.evaluate( x );
+    }
+
+    using Parent::domain;
+    using Parent::operator();
+    using Parent::isInside;
+    using Parent::isContained;
+  };
+
+} // math namespace
+} // scion namespace
+} // njoy namespace
+
+#endif

--- a/src/scion/math/LinearLinearTable.hpp
+++ b/src/scion/math/LinearLinearTable.hpp
@@ -22,11 +22,12 @@ namespace math {
 
     /* type aliases */
     using Parent = FunctionBase< LinearLinearTable< X, Y >, X, Y >;
+    using Table = interpolation::Table< interpolation::LinearLinear,
+                                        std::vector< X >,
+                                        std::vector< Y > >;
 
     /* fields */
-    interpolation::Table< interpolation::LinearLinear,
-                          std::vector< X >,
-                          std::vector< Y > > table_;
+    Table table_;
 
     /* auxiliary function */
 

--- a/src/scion/math/LinearLinearTable/src/ctor.hpp
+++ b/src/scion/math/LinearLinearTable/src/ctor.hpp
@@ -3,10 +3,9 @@ private:
 /**
  *  @brief Private intermediate constructor
  */
-LinearLinearTable( IntervalDomain< X >&& domain,
-                   std::vector< X >&& x, std::vector< Y >&& y ) :
-  Parent( std::move( domain ) ),
-  table_( std::move( x ), std::move( y ) ) {}
+LinearLinearTable( Table&& table ) :
+  Parent( IntervalDomain( table.x().front(), table.x().back() ) ),
+  table_( std::move( table ) ) {}
 
 
 public:
@@ -18,5 +17,4 @@ public:
  *  @param y   the y values of the tabulated data
  */
 LinearLinearTable( std::vector< X > x, std::vector< Y > y ) :
-  LinearLinearTable( IntervalDomain( x.front(), x.back() ),
-                     std::move( x ), std::move( y ) ) {}
+  LinearLinearTable( Table( std::move( x ), std::move( y ) ) ) {}

--- a/src/scion/math/LinearLinearTable/src/ctor.hpp
+++ b/src/scion/math/LinearLinearTable/src/ctor.hpp
@@ -1,0 +1,22 @@
+private:
+
+/**
+ *  @brief Private intermediate constructor
+ */
+LinearLinearTable( IntervalDomain< X >&& domain,
+                   std::vector< X >&& x, std::vector< Y >&& y ) :
+  Parent( std::move( domain ) ),
+  table_( std::move( x ), std::move( y ) ) {}
+
+
+public:
+
+/**
+ *  @brief Constructor
+ *
+ *  @param x   the x values of the tabulated data
+ *  @param y   the y values of the tabulated data
+ */
+LinearLinearTable( std::vector< X > x, std::vector< Y > y ) :
+  LinearLinearTable( IntervalDomain( x.front(), x.back() ),
+                     std::move( x ), std::move( y ) ) {}

--- a/src/scion/math/LinearLinearTable/test/CMakeLists.txt
+++ b/src/scion/math/LinearLinearTable/test/CMakeLists.txt
@@ -1,0 +1,18 @@
+
+add_executable( scion.math.LinearLinearTable.test LinearLinearTable.test.cpp )
+target_compile_options( scion.math.LinearLinearTable.test PRIVATE ${${PREFIX}_common_flags}
+$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
+${${PREFIX}_DEBUG_flags}
+$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
+$<$<CONFIG:RELEASE>:
+${${PREFIX}_RELEASE_flags}
+$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
+$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
+
+${CXX_appended_flags} ${scion_appended_flags} )
+target_link_libraries( scion.math.LinearLinearTable.test PUBLIC scion )
+file( GLOB resources "resources/*" )
+foreach( resource ${resources})
+    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
+endforeach()
+add_test( NAME scion.math.LinearLinearTable COMMAND scion.math.LinearLinearTable.test )

--- a/src/scion/math/LinearLinearTable/test/LinearLinearTable.test.cpp
+++ b/src/scion/math/LinearLinearTable/test/LinearLinearTable.test.cpp
@@ -1,0 +1,95 @@
+#define CATCH_CONFIG_MAIN
+
+#include "catch.hpp"
+#include "scion/math/LinearLinearTable.hpp"
+
+// other includes
+
+// convenience typedefs
+using namespace njoy::scion;
+template < typename X, typename Y = X > using LinearLinearTable = math::LinearLinearTable< X, Y >;
+template < typename X > using IntervalDomain = math::IntervalDomain< X >;
+
+SCENARIO( "LinearLinearTable" ) {
+
+  GIVEN( "tabulated data" ) {
+
+    WHEN( "the data is given explicitly" ) {
+
+      std::vector< double > x = { 1., 2., 3., 4. };
+      std::vector< double > y = { 4., 3., 2., 1. };
+
+      LinearLinearTable< double > chunk( std::move( x ), std::move( y ) );
+
+      THEN( "a LinearLinearTable can be constructed and members can be tested" ) {
+
+        CHECK( 4 == chunk.x().size() );
+        CHECK( 4 == chunk.y().size() );
+        CHECK( 1. == Approx( chunk.x()[0] ) );
+        CHECK( 2. == Approx( chunk.x()[1] ) );
+        CHECK( 3. == Approx( chunk.x()[2] ) );
+        CHECK( 4. == Approx( chunk.x()[3] ) );
+        CHECK( 4. == Approx( chunk.y()[0] ) );
+        CHECK( 3. == Approx( chunk.y()[1] ) );
+        CHECK( 2. == Approx( chunk.y()[2] ) );
+        CHECK( 1. == Approx( chunk.y()[3] ) );
+
+        CHECK( true == std::holds_alternative< IntervalDomain< double > >( chunk.domain() ) );
+      } // THEN
+
+      THEN( "a LinearLinearTable can be evaluated" ) {
+
+        // values of x in the x grid
+        CHECK( 4. == Approx( chunk.evaluate( 1. ) ) );
+        CHECK( 3. == Approx( chunk.evaluate( 2. ) ) );
+        CHECK( 2. == Approx( chunk.evaluate( 3. ) ) );
+        CHECK( 1. == Approx( chunk.evaluate( 4. ) ) );
+
+        // values of x outside the x grid
+        CHECK( 0. == Approx( chunk.evaluate( 0. ) ) );
+        CHECK( 0. == Approx( chunk.evaluate( 5. ) ) );
+
+        // values of x inside the x grid
+        CHECK( 3.5 == Approx( chunk.evaluate( 1.5 ) ) );
+        CHECK( 1.5 == Approx( chunk.evaluate( 3.5 ) ) );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+
+  GIVEN( "invalid data for a LinearLinearTable object" ) {
+
+    WHEN( "there are not enough values in the x or y grid" ) {
+
+      std::vector< double > empty = {};
+      std::vector< double > one = { 1. };
+
+      THEN( "an exception is thrown" ) {
+
+        CHECK_THROWS( LinearLinearTable< double >( empty, empty ) );
+        CHECK_THROWS( LinearLinearTable< double >( one, one ) );
+      } // THEN
+    } // WHEN
+
+    WHEN( "the x and y grid do not have the same number of points" ) {
+
+      std::vector< double > x = { 1., 2., 3., 4. };
+      std::vector< double > y = { 4., 3., 2. };
+
+      THEN( "an exception is thrown" ) {
+
+        CHECK_THROWS( LinearLinearTable< double >( std::move( x ), std::move( y ) ) );
+      } // THEN
+    } // WHEN
+
+    WHEN( "the x grid is not sorted" ) {
+
+      std::vector< double > x = { 1., 3., 2., 4. };
+      std::vector< double > y = { 4., 3., 2., 1. };
+
+      THEN( "an exception is thrown" ) {
+
+        CHECK_THROWS( LinearLinearTable< double >( std::move( x ), std::move( y ) ) );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+} // SCENARIO


### PR DESCRIPTION
The LinearLinearTable is a single interpolation zone component that will serve as a basis of the InterpolationTable.