### PR TITLE
Fix/legendre companion

### DIFF
--- a/src/scion/math/ChebyshevApproximation/src/linearise.hpp
+++ b/src/scion/math/ChebyshevApproximation/src/linearise.hpp
@@ -6,5 +6,28 @@
 template < typename Convergence = linearisation::ToleranceConvergence< X, Y > >
 LinearLinearTable< X, Y > linearise( Convergence&& convergence = Convergence() ) const {
 
-  throw std::exception();
+  if ( 0 == this->order() ) {
+
+    return LinearLinearTable< X, Y >( { -1., +1. },
+                                      { this->coefficients().front(),
+                                        this->coefficients().front() } );
+  }
+  else if ( 1 == this->order() ) {
+
+    const auto a = this->coefficients().back();
+    const auto b = this->coefficients().front();
+    return LinearLinearTable< X, Y >( { -1., +1. }, { b - a, b + a } );
+  }
+  else {
+
+    std::vector< X > x;
+    std::vector< Y > y;
+    linearisation::Lineariser lineariser( x, y );
+    lineariser( linearisation::grid( *this, X( -1. ), X( +1. ) ),
+                *this,
+                std::forward< Convergence >( convergence ),
+                linearisation::MidpointSplit< X >() );
+
+    return LinearLinearTable< X, Y >( std::move( x ), std::move( y ) );
+  }
 }

--- a/src/scion/math/ChebyshevSeries.hpp
+++ b/src/scion/math/ChebyshevSeries.hpp
@@ -12,7 +12,6 @@
 #include "scion/math/clenshaw.hpp"
 #include "scion/math/compare.hpp"
 #include "scion/math/matrix.hpp"
-#include "scion/math/newton.hpp"
 #include "scion/math/FunctionBase.hpp"
 #include "scion/math/LinearLinearTable.hpp"
 

--- a/src/scion/math/ChebyshevSeries/src/companionMatrix.hpp
+++ b/src/scion/math/ChebyshevSeries/src/companionMatrix.hpp
@@ -8,11 +8,6 @@ Matrix< Y > companionMatrix( const Y& a ) const {
   // Journal of Engineering Mathematics volume 56, pages 203–219 (2006)
   // doi: 10.1007/s10665-006-9087-5
 
-  // remark: the companion matrix used by numpy is equal to diag * matrix * diag
-  // where matrix is the matrix calculated in this function and diag is a
-  // diagonal matrix where the i-th element on the diagonal is equal to 1 for
-  // i = 0 and equal to sqrt( 1 / 2 ) for all other i.
-
   // This does not check for order 0: this case is explicitly handled in the
   // roots( ... ) method.
 
@@ -32,6 +27,44 @@ Matrix< Y > companionMatrix( const Y& a ) const {
   }
   matrix( order - 1, order - 2 ) += Y( 0.5 );
   matrix( order - 1, order - 1 ) = - this->coefficients()[order - 1] / scale;
+
+  matrix.transposeInPlace();
+  matrix.reverseInPlace();
+
+  return matrix;
+}
+
+Matrix< Y > companionMatrixNumpy( const Y& a ) const {
+
+  // Reference: numpy
+
+  // This does not check for order 0 or 1: this case is explicitly handled in the
+  // roots( ... ) method.
+
+  const unsigned int order = this->order();
+  const Y scale = this->coefficients().back() * Y( 2 );
+
+  Matrix< X > matrix( order, order );
+  matrix.setZero();
+
+  matrix( 0, 1 ) = std::sqrt( Y( 0.5 ) );
+  matrix( 1, 0 ) = matrix( 0, 1 );
+  for ( unsigned int i = 1; i < order - 1; ++i ) {
+
+    matrix( i, i + 1 ) = Y( 0.5 );
+    matrix( i + 1, i ) = matrix( i, i + 1 );
+  }
+  matrix( order - 1, order - 2 ) = matrix( order - 2, order - 1 );
+
+  matrix( order - 1, 0 ) -= ( this->coefficients().front() - a ) / scale
+                            * std::sqrt( Y( 2. ) );
+  for ( unsigned int i = 1; i < order; ++i ) {
+
+    matrix( order - 1, i ) -= this->coefficients()[i] / scale;
+  }
+
+  matrix.transposeInPlace();
+  matrix.reverseInPlace();
 
   return matrix;
 }

--- a/src/scion/math/ChebyshevSeries/src/roots.hpp
+++ b/src/scion/math/ChebyshevSeries/src/roots.hpp
@@ -23,7 +23,7 @@ std::vector< X > roots( const Y& a = Y( 0. ) ) const {
   }
   else if ( 1 < this->order() ) {
 
-    Eigen::EigenSolver< Matrix< Y > > solver( this->companionMatrix( a ), false );
+    Eigen::EigenSolver< Matrix< Y > > solver( this->companionMatrixNumpy( a ), false );
     ChebyshevSeries derivative = this->derivative();
     auto functor = [&a, this] ( const X& x ) { return this->evaluate( x ) - a; };
 
@@ -31,7 +31,7 @@ std::vector< X > roots( const Y& a = Y( 0. ) ) const {
 
       if ( isCloseToZero( value.imag() ) ) {
 
-        roots.emplace_back( newton( value.real(), functor, derivative ) );
+        roots.emplace_back( value.real() );
       }
     }
 

--- a/src/scion/math/LegendreSeries.hpp
+++ b/src/scion/math/LegendreSeries.hpp
@@ -12,7 +12,6 @@
 #include "scion/math/clenshaw.hpp"
 #include "scion/math/compare.hpp"
 #include "scion/math/matrix.hpp"
-#include "scion/math/newton.hpp"
 #include "scion/math/FunctionBase.hpp"
 #include "scion/math/LinearLinearTable.hpp"
 

--- a/src/scion/math/LegendreSeries/src/companionMatrix.hpp
+++ b/src/scion/math/LegendreSeries/src/companionMatrix.hpp
@@ -1,4 +1,4 @@
-Matrix< Y > companionMatrix( const Y& a ) const {
+Matrix< Y > companionMatrixBoyd( const Y& a ) const {
 
   // Reference:
   // John P. Boyd
@@ -8,12 +8,7 @@ Matrix< Y > companionMatrix( const Y& a ) const {
   // Journal of Engineering Mathematics volume 56, pages 203–219 (2006)
   // doi: 10.1007/s10665-006-9087-5
 
-  // remark: the companion matrix used by numpy is equal to diag * matrix * diag
-  // where matrix is the matrix calculated in this function and diag is a
-  // diagonal matrix where the i-th element on the diagonal is equal to
-  // sqrt( 2 * i + 1 )
-
-  // This does not check for order 0: this case is explicitly handled in the
+  // This does not check for order 0 or 1: this case is explicitly handled in the
   // roots( ... ) method.
 
   const unsigned int order = this->order();
@@ -22,7 +17,7 @@ Matrix< Y > companionMatrix( const Y& a ) const {
   Matrix< X > matrix( order, order );
   matrix.setZero();
 
-  matrix( order - 1, 0 ) = - ( this->coefficients()[0] - a ) / scale;
+  matrix( order - 1, 0 ) = - ( this->coefficients().front() - a ) / scale;
   matrix( 0, 1 ) = Y( 1. );
   for ( unsigned int i = 1; i < order - 1; ++i ) {
 
@@ -32,6 +27,44 @@ Matrix< Y > companionMatrix( const Y& a ) const {
   }
   matrix( order - 1, order - 2 ) += Y( order - 1 ) / Y( 2 * order - 1 );
   matrix( order - 1, order - 1 ) = - this->coefficients()[order - 1] / scale;
+
+  matrix.transposeInPlace();
+  matrix.reverseInPlace();
+
+  return matrix;
+}
+
+Matrix< Y > companionMatrix( const Y& a ) const {
+
+  // Reference: numpy
+
+  // This does not check for order 0 or 1: this case is explicitly handled in the
+  // roots( ... ) method.
+
+  const unsigned int order = this->order();
+  const Y scale = this->coefficients().back() * Y( 2 * order - 1 ) / Y( order );
+
+  Matrix< X > matrix( order, order );
+  matrix.setZero();
+
+  for ( unsigned int i = 0; i < order - 1; ++i ) {
+
+    matrix( i, i + 1 ) = Y( i + 1 ) / std::sqrt( Y( 2 * i + 1 ) * Y( 2 * i + 3 ) );
+    matrix( i + 1, i ) = matrix( i, i + 1 );
+  }
+  matrix( order - 1, order - 2 ) = matrix( order - 2, order - 1 );
+
+  matrix( order - 1, 0 ) -= ( this->coefficients().front() - a ) / scale
+                            * std::sqrt( Y( 2 * order - 1 ) );
+  for ( unsigned int i = 1; i < order; ++i ) {
+
+    matrix( order - 1, i ) -= this->coefficients()[i] / scale
+                              / std::sqrt( Y( 2 * i + 1 ) )
+                              * std::sqrt( Y( 2 * order - 1 ) );
+  }
+
+  matrix.transposeInPlace();
+  matrix.reverseInPlace();
 
   return matrix;
 }

--- a/src/scion/math/LegendreSeries/src/companionMatrix.hpp
+++ b/src/scion/math/LegendreSeries/src/companionMatrix.hpp
@@ -1,4 +1,4 @@
-Matrix< Y > companionMatrixBoyd( const Y& a ) const {
+Matrix< Y > companionMatrix( const Y& a ) const {
 
   // Reference:
   // John P. Boyd
@@ -34,7 +34,7 @@ Matrix< Y > companionMatrixBoyd( const Y& a ) const {
   return matrix;
 }
 
-Matrix< Y > companionMatrix( const Y& a ) const {
+Matrix< Y > companionMatrixNumpy( const Y& a ) const {
 
   // Reference: numpy
 

--- a/src/scion/math/LegendreSeries/src/roots.hpp
+++ b/src/scion/math/LegendreSeries/src/roots.hpp
@@ -32,7 +32,7 @@ std::vector< X > roots( const Y& a = Y( 0. ) ) const {
 
       if ( isCloseToZero( value.imag() ) ) {
 
-        roots.emplace_back( newton( value.real(), functor, derivative ) );
+        roots.emplace_back( value.real() );
       }
     }
 

--- a/src/scion/math/LegendreSeries/src/roots.hpp
+++ b/src/scion/math/LegendreSeries/src/roots.hpp
@@ -23,7 +23,7 @@ std::vector< X > roots( const Y& a = Y( 0. ) ) const {
   }
   else if ( 1 < this->order() ) {
 
-    Eigen::EigenSolver< Matrix< Y > > solver( this->companionMatrix( a ), false );
+    Eigen::EigenSolver< Matrix< Y > > solver( this->companionMatrixNumpy( a ), false );
 
     LegendreSeries derivative = this->derivative();
     auto functor = [&a, this] ( const X& x ) { return this->evaluate( x ) - a; };

--- a/src/scion/math/PolynomialSeries.hpp
+++ b/src/scion/math/PolynomialSeries.hpp
@@ -12,7 +12,6 @@
 #include "scion/math/compare.hpp"
 #include "scion/math/horner.hpp"
 #include "scion/math/matrix.hpp"
-#include "scion/math/newton.hpp"
 #include "scion/math/FunctionBase.hpp"
 #include "scion/math/LinearLinearTable.hpp"
 

--- a/src/scion/math/PolynomialSeries/src/companionMatrix.hpp
+++ b/src/scion/math/PolynomialSeries/src/companionMatrix.hpp
@@ -1,6 +1,6 @@
 Matrix< Y > companionMatrix( const Y& a ) const {
 
-  // This does not check for order 0: this case is explicitly handled in the
+  // This does not check for order 0 or 1: this case is explicitly handled in the
   // roots( ... ) method.
 
   const unsigned int order = this->order();

--- a/src/scion/math/PolynomialSeries/src/roots.hpp
+++ b/src/scion/math/PolynomialSeries/src/roots.hpp
@@ -33,7 +33,7 @@ std::vector< X > roots( const Y& a = Y( 0. ) ) const {
 
       if ( isCloseToZero( value.imag() ) ) {
 
-        roots.emplace_back( newton( value.real(), functor, derivative ) );
+        roots.emplace_back( value.real() );
       }
     }
 

--- a/src/scion/math/newton.hpp
+++ b/src/scion/math/newton.hpp
@@ -2,7 +2,7 @@
 #define NJOY_SCION_MATH_NEWTON
 
 // system includes
-#include <iostream>
+
 // other includes
 #include "scion/math/compare.hpp"
 


### PR DESCRIPTION
An update to the way the companion matrices are calculated for the Legendre and Chebyshev polynomial expansions. This update was required to get Legendre series read from MF4 MT2 for U235 ENDF/B-VIII to linearise properly.

The update consists of slightly different ways to calculate the companion matrices (as given in numpy).