### PR TITLE
Feature/more linearisation tests

### DIFF
--- a/python/test/math/Test_scion_math_ChebyshevSeries.py
+++ b/python/test/math/Test_scion_math_ChebyshevSeries.py
@@ -7,6 +7,8 @@ import sys
 # local imports
 from scion.math import ChebyshevSeries
 from scion.math import IntervalDomain
+from scion.linearisation import ToleranceConvergence
+from scion.interpolation import InterpolationType
 
 class Test_scion_math_ChebyshevSeries( unittest.TestCase ) :
     """Unit test for the ChebyshevSeries class."""
@@ -30,17 +32,6 @@ class Test_scion_math_ChebyshevSeries( unittest.TestCase ) :
             self.assertAlmostEqual(  -8.0, chunk( x =  0. ) )
             self.assertAlmostEqual(   0.0, chunk( x =  1. ) )
             self.assertAlmostEqual( -30.0, chunk( x = -1. ) )
-
-            # verify roots
-            roots = chunk.roots()
-            self.assertEqual( 3, len( roots ) )
-            self.assertAlmostEqual( 1.0, roots[0] )
-            self.assertAlmostEqual( 2.0, roots[1] )
-            self.assertAlmostEqual( 4.0, roots[2] )
-
-            roots = chunk.roots( -8. )
-            self.assertEqual( 1, len( roots ) )
-            self.assertAlmostEqual( 0.0, roots[0] )
 
             # verify derivative
             first = chunk.derivative()
@@ -87,6 +78,77 @@ class Test_scion_math_ChebyshevSeries( unittest.TestCase ) :
             self.assertAlmostEqual(  3.625, primitive.coefficients[2] )
             self.assertAlmostEqual( -0.5833333333333334, primitive.coefficients[3] )
             self.assertAlmostEqual(  0.03125, primitive.coefficients[4] )
+
+            # verify roots
+            roots = chunk.roots()
+            self.assertEqual( 3, len( roots ) )
+            self.assertAlmostEqual( 1.0, roots[0] )
+            self.assertAlmostEqual( 2.0, roots[1] )
+            self.assertAlmostEqual( 4.0, roots[2] )
+
+            roots = chunk.roots( -8. )
+            self.assertEqual( 1, len( roots ) )
+            self.assertAlmostEqual( 0.0, roots[0] )
+
+            # verify linearisation
+            convergence = ToleranceConvergence( 0.01 )
+            linear = chunk.linearise( convergence )
+
+            self.assertEqual( 21, linear.number_points )
+            self.assertEqual( 1, linear.number_regions )
+
+            self.assertEqual( 21, len( linear.x ) )
+            self.assertEqual( 21, len( linear.y ) )
+            self.assertEqual( 1, len( linear.boundaries ) )
+            self.assertEqual( 1, len( linear.interpolants ) )
+
+            self.assertEqual( 20, linear.boundaries[0] )
+
+            self.assertEqual( InterpolationType.LinearLinear, linear.interpolants[0] )
+
+            self.assertAlmostEqual( -1.0      , linear.x[0] )
+            self.assertAlmostEqual( -0.75     , linear.x[1] )
+            self.assertAlmostEqual( -0.5      , linear.x[2] )
+            self.assertAlmostEqual( -0.25     , linear.x[3] )
+            self.assertAlmostEqual( -0.125    , linear.x[4] )
+            self.assertAlmostEqual(  0.0      , linear.x[5] )
+            self.assertAlmostEqual(  0.125    , linear.x[6] )
+            self.assertAlmostEqual(  0.25     , linear.x[7] )
+            self.assertAlmostEqual(  0.375    , linear.x[8] )
+            self.assertAlmostEqual(  0.5      , linear.x[9] )
+            self.assertAlmostEqual(  0.625    , linear.x[10] )
+            self.assertAlmostEqual(  0.6875   , linear.x[11] )
+            self.assertAlmostEqual(  0.75     , linear.x[12] )
+            self.assertAlmostEqual(  0.8125   , linear.x[13] )
+            self.assertAlmostEqual(  0.875    , linear.x[14] )
+            self.assertAlmostEqual(  0.90625  , linear.x[15] )
+            self.assertAlmostEqual(  0.9375   , linear.x[16] )
+            self.assertAlmostEqual(  0.96875  , linear.x[17] )
+            self.assertAlmostEqual(  0.984375 , linear.x[18] )
+            self.assertAlmostEqual(  0.9921875, linear.x[19] )
+            self.assertAlmostEqual(  1.0      , linear.x[20] )
+
+            self.assertAlmostEqual( -30.0      , linear.y[0] )
+            self.assertAlmostEqual( -22.859375 , linear.y[1] )
+            self.assertAlmostEqual( -16.875    , linear.y[2] )
+            self.assertAlmostEqual( -11.953125 , linear.y[3] )
+            self.assertAlmostEqual( -9.86132813, linear.y[4] )
+            self.assertAlmostEqual( -8.0       , linear.y[5] )
+            self.assertAlmostEqual( -6.35742188, linear.y[6] )
+            self.assertAlmostEqual( -4.921875  , linear.y[7] )
+            self.assertAlmostEqual( -3.68164063, linear.y[8] )
+            self.assertAlmostEqual( -2.625     , linear.y[9] )
+            self.assertAlmostEqual( -1.74023438, linear.y[10] )
+            self.assertAlmostEqual( -1.35864258, linear.y[11] )
+            self.assertAlmostEqual( -1.015625  , linear.y[12] )
+            self.assertAlmostEqual( -0.70971680, linear.y[13] )
+            self.assertAlmostEqual( -0.43945313, linear.y[14] )
+            self.assertAlmostEqual( -0.31723023, linear.y[15] )
+            self.assertAlmostEqual( -0.20336914, linear.y[16] )
+            self.assertAlmostEqual( -0.09768677, linear.y[17] )
+            self.assertAlmostEqual( -0.04785538, linear.y[18] )
+            self.assertAlmostEqual( -0.02368212, linear.y[19] )
+            self.assertAlmostEqual(  0.0       , linear.y[20] )
 
             # verify arithmetic operators
             small = ChebyshevSeries( [ 3., 0., 1. ] )

--- a/python/test/math/Test_scion_math_LegendreSeries.py
+++ b/python/test/math/Test_scion_math_LegendreSeries.py
@@ -7,6 +7,8 @@ import sys
 # local imports
 from scion.math import LegendreSeries
 from scion.math import IntervalDomain
+from scion.linearisation import ToleranceConvergence
+from scion.interpolation import InterpolationType
 
 class Test_scion_math_LegendreSeries( unittest.TestCase ) :
     """Unit test for the LegendreSeries class."""
@@ -87,6 +89,66 @@ class Test_scion_math_LegendreSeries( unittest.TestCase ) :
             roots = chunk.roots( -8. )
             self.assertEqual( 1, len( roots ) )
             self.assertAlmostEqual( 0.0, roots[0] )
+
+            # verify linearisation
+            convergence = ToleranceConvergence( 0.01 )
+            linear = chunk.linearise( convergence )
+
+            self.assertEqual( 21, linear.number_points )
+            self.assertEqual( 1, linear.number_regions )
+
+            self.assertEqual( 21, len( linear.x ) )
+            self.assertEqual( 21, len( linear.y ) )
+            self.assertEqual( 1, len( linear.boundaries ) )
+            self.assertEqual( 1, len( linear.interpolants ) )
+
+            self.assertEqual( 20, linear.boundaries[0] )
+
+            self.assertEqual( InterpolationType.LinearLinear, linear.interpolants[0] )
+
+            self.assertAlmostEqual( -1.0      , linear.x[0] )
+            self.assertAlmostEqual( -0.75     , linear.x[1] )
+            self.assertAlmostEqual( -0.5      , linear.x[2] )
+            self.assertAlmostEqual( -0.25     , linear.x[3] )
+            self.assertAlmostEqual( -0.125    , linear.x[4] )
+            self.assertAlmostEqual(  0.0      , linear.x[5] )
+            self.assertAlmostEqual(  0.125    , linear.x[6] )
+            self.assertAlmostEqual(  0.25     , linear.x[7] )
+            self.assertAlmostEqual(  0.375    , linear.x[8] )
+            self.assertAlmostEqual(  0.5      , linear.x[9] )
+            self.assertAlmostEqual(  0.625    , linear.x[10] )
+            self.assertAlmostEqual(  0.6875   , linear.x[11] )
+            self.assertAlmostEqual(  0.75     , linear.x[12] )
+            self.assertAlmostEqual(  0.8125   , linear.x[13] )
+            self.assertAlmostEqual(  0.875    , linear.x[14] )
+            self.assertAlmostEqual(  0.90625  , linear.x[15] )
+            self.assertAlmostEqual(  0.9375   , linear.x[16] )
+            self.assertAlmostEqual(  0.96875  , linear.x[17] )
+            self.assertAlmostEqual(  0.984375 , linear.x[18] )
+            self.assertAlmostEqual(  0.9921875, linear.x[19] )
+            self.assertAlmostEqual(  1.0      , linear.x[20] )
+
+            self.assertAlmostEqual( -30.0      , linear.y[0] )
+            self.assertAlmostEqual( -22.859375 , linear.y[1] )
+            self.assertAlmostEqual( -16.875    , linear.y[2] )
+            self.assertAlmostEqual( -11.953125 , linear.y[3] )
+            self.assertAlmostEqual( -9.86132813, linear.y[4] )
+            self.assertAlmostEqual( -8.0       , linear.y[5] )
+            self.assertAlmostEqual( -6.35742188, linear.y[6] )
+            self.assertAlmostEqual( -4.921875  , linear.y[7] )
+            self.assertAlmostEqual( -3.68164063, linear.y[8] )
+            self.assertAlmostEqual( -2.625     , linear.y[9] )
+            self.assertAlmostEqual( -1.74023438, linear.y[10] )
+            self.assertAlmostEqual( -1.35864258, linear.y[11] )
+            self.assertAlmostEqual( -1.015625  , linear.y[12] )
+            self.assertAlmostEqual( -0.70971680, linear.y[13] )
+            self.assertAlmostEqual( -0.43945313, linear.y[14] )
+            self.assertAlmostEqual( -0.31723023, linear.y[15] )
+            self.assertAlmostEqual( -0.20336914, linear.y[16] )
+            self.assertAlmostEqual( -0.09768677, linear.y[17] )
+            self.assertAlmostEqual( -0.04785538, linear.y[18] )
+            self.assertAlmostEqual( -0.02368212, linear.y[19] )
+            self.assertAlmostEqual(  0.0       , linear.y[20] )
 
             # verify arithmetic operators
             small = LegendreSeries( [ 3., 0., 1. ] )

--- a/python/test/math/Test_scion_math_PolynomialSeries.py
+++ b/python/test/math/Test_scion_math_PolynomialSeries.py
@@ -7,6 +7,8 @@ import sys
 # local imports
 from scion.math import PolynomialSeries
 from scion.math import IntervalDomain
+from scion.linearisation import ToleranceConvergence
+from scion.interpolation import InterpolationType
 
 class Test_scion_math_PolynomialSeries( unittest.TestCase ) :
     """Unit test for the PolynomialSeries class."""
@@ -105,6 +107,66 @@ class Test_scion_math_PolynomialSeries( unittest.TestCase ) :
             roots = chunk.roots( -8. )
             self.assertEqual( 1, len( roots ) )
             self.assertAlmostEqual( 0.0, roots[0] )
+
+            # verify linearisation
+            convergence = ToleranceConvergence( 0.01 )
+            linear = chunk.linearise( convergence )
+
+            self.assertEqual( 21, linear.number_points )
+            self.assertEqual( 1, linear.number_regions )
+
+            self.assertEqual( 21, len( linear.x ) )
+            self.assertEqual( 21, len( linear.y ) )
+            self.assertEqual( 1, len( linear.boundaries ) )
+            self.assertEqual( 1, len( linear.interpolants ) )
+
+            self.assertEqual( 20, linear.boundaries[0] )
+
+            self.assertEqual( InterpolationType.LinearLinear, linear.interpolants[0] )
+
+            self.assertAlmostEqual( -1.0      , linear.x[0] )
+            self.assertAlmostEqual( -0.75     , linear.x[1] )
+            self.assertAlmostEqual( -0.5      , linear.x[2] )
+            self.assertAlmostEqual( -0.25     , linear.x[3] )
+            self.assertAlmostEqual( -0.125    , linear.x[4] )
+            self.assertAlmostEqual(  0.0      , linear.x[5] )
+            self.assertAlmostEqual(  0.125    , linear.x[6] )
+            self.assertAlmostEqual(  0.25     , linear.x[7] )
+            self.assertAlmostEqual(  0.375    , linear.x[8] )
+            self.assertAlmostEqual(  0.5      , linear.x[9] )
+            self.assertAlmostEqual(  0.625    , linear.x[10] )
+            self.assertAlmostEqual(  0.6875   , linear.x[11] )
+            self.assertAlmostEqual(  0.75     , linear.x[12] )
+            self.assertAlmostEqual(  0.8125   , linear.x[13] )
+            self.assertAlmostEqual(  0.875    , linear.x[14] )
+            self.assertAlmostEqual(  0.90625  , linear.x[15] )
+            self.assertAlmostEqual(  0.9375   , linear.x[16] )
+            self.assertAlmostEqual(  0.96875  , linear.x[17] )
+            self.assertAlmostEqual(  0.984375 , linear.x[18] )
+            self.assertAlmostEqual(  0.9921875, linear.x[19] )
+            self.assertAlmostEqual(  1.0      , linear.x[20] )
+
+            self.assertAlmostEqual( -30.0      , linear.y[0] )
+            self.assertAlmostEqual( -22.859375 , linear.y[1] )
+            self.assertAlmostEqual( -16.875    , linear.y[2] )
+            self.assertAlmostEqual( -11.953125 , linear.y[3] )
+            self.assertAlmostEqual( -9.86132813, linear.y[4] )
+            self.assertAlmostEqual( -8.0       , linear.y[5] )
+            self.assertAlmostEqual( -6.35742188, linear.y[6] )
+            self.assertAlmostEqual( -4.921875  , linear.y[7] )
+            self.assertAlmostEqual( -3.68164063, linear.y[8] )
+            self.assertAlmostEqual( -2.625     , linear.y[9] )
+            self.assertAlmostEqual( -1.74023438, linear.y[10] )
+            self.assertAlmostEqual( -1.35864258, linear.y[11] )
+            self.assertAlmostEqual( -1.015625  , linear.y[12] )
+            self.assertAlmostEqual( -0.70971680, linear.y[13] )
+            self.assertAlmostEqual( -0.43945313, linear.y[14] )
+            self.assertAlmostEqual( -0.31723023, linear.y[15] )
+            self.assertAlmostEqual( -0.20336914, linear.y[16] )
+            self.assertAlmostEqual( -0.09768677, linear.y[17] )
+            self.assertAlmostEqual( -0.04785538, linear.y[18] )
+            self.assertAlmostEqual( -0.02368212, linear.y[19] )
+            self.assertAlmostEqual(  0.0       , linear.y[20] )
 
             # verify arithmetic operators
             small = PolynomialSeries( [ 3., 0., 1. ] )

--- a/src/scion/math/ChebyshevSeries/test/ChebyshevSeries.test.cpp
+++ b/src/scion/math/ChebyshevSeries/test/ChebyshevSeries.test.cpp
@@ -9,6 +9,12 @@
 using namespace njoy::scion;
 template < typename X, typename Y = X > using ChebyshevSeries = math::ChebyshevSeries< X, Y >;
 template < typename X > using IntervalDomain = math::IntervalDomain< X >;
+template < typename X, typename Y = X >
+using InterpolationTable = math::InterpolationTable< X, Y >;
+template < typename X > using IntervalDomain = math::IntervalDomain< X >;
+using InterpolationType = interpolation::InterpolationType;
+template< typename X, typename Y = X >
+using ToleranceConvergence = linearisation::ToleranceConvergence< X, Y >;
 
 SCENARIO( "ChebyshevSeries" ) {
 
@@ -107,6 +113,68 @@ SCENARIO( "ChebyshevSeries" ) {
         CHECK(  3.625 == Approx( primitive.coefficients()[2] ) );
         CHECK( -0.5833333333333334 == Approx( primitive.coefficients()[3] ) );
         CHECK(  0.03125 == Approx( primitive.coefficients()[4] ) );
+      } // THEN
+
+      THEN( "a PolynomialSeries can be linearised" ) {
+
+        ToleranceConvergence< double > tolerance( 0.01 );
+        InterpolationTable< double > linear = chunk.linearise( tolerance );
+
+        CHECK( 21 == linear.numberPoints() );
+        CHECK( 1 == linear.numberRegions() );
+
+        CHECK( 21 == linear.x().size() );
+        CHECK( 21 == linear.y().size() );
+        CHECK( 1 == linear.boundaries().size() );
+        CHECK( 1 == linear.interpolants().size() );
+
+        CHECK( 20 == linear.boundaries()[0] );
+
+        CHECK( InterpolationType::LinearLinear == linear.interpolants()[0] );
+
+        CHECK( -1.0       == Approx( linear.x()[0] ) );
+        CHECK( -0.75      == Approx( linear.x()[1] ) );
+        CHECK( -0.5       == Approx( linear.x()[2] ) );
+        CHECK( -0.25      == Approx( linear.x()[3] ) );
+        CHECK( -0.125     == Approx( linear.x()[4] ) );
+        CHECK(  0.0       == Approx( linear.x()[5] ) );
+        CHECK(  0.125     == Approx( linear.x()[6] ) );
+        CHECK(  0.25      == Approx( linear.x()[7] ) );
+        CHECK(  0.375     == Approx( linear.x()[8] ) );
+        CHECK(  0.5       == Approx( linear.x()[9] ) );
+        CHECK(  0.625     == Approx( linear.x()[10] ) );
+        CHECK(  0.6875    == Approx( linear.x()[11] ) );
+        CHECK(  0.75      == Approx( linear.x()[12] ) );
+        CHECK(  0.8125    == Approx( linear.x()[13] ) );
+        CHECK(  0.875     == Approx( linear.x()[14] ) );
+        CHECK(  0.90625   == Approx( linear.x()[15] ) );
+        CHECK(  0.9375    == Approx( linear.x()[16] ) );
+        CHECK(  0.96875   == Approx( linear.x()[17] ) );
+        CHECK(  0.984375  == Approx( linear.x()[18] ) );
+        CHECK(  0.9921875 == Approx( linear.x()[19] ) );
+        CHECK(  1.0       == Approx( linear.x()[20] ) );
+
+        CHECK( -30.0       == Approx( linear.y()[0] ) );
+        CHECK( -22.859375  == Approx( linear.y()[1] ) );
+        CHECK( -16.875     == Approx( linear.y()[2] ) );
+        CHECK( -11.953125  == Approx( linear.y()[3] ) );
+        CHECK( -9.86132813 == Approx( linear.y()[4] ) );
+        CHECK( -8.0        == Approx( linear.y()[5] ) );
+        CHECK( -6.35742188 == Approx( linear.y()[6] ) );
+        CHECK( -4.921875   == Approx( linear.y()[7] ) );
+        CHECK( -3.68164063 == Approx( linear.y()[8] ) );
+        CHECK( -2.625      == Approx( linear.y()[9] ) );
+        CHECK( -1.74023438 == Approx( linear.y()[10] ) );
+        CHECK( -1.35864258 == Approx( linear.y()[11] ) );
+        CHECK( -1.015625   == Approx( linear.y()[12] ) );
+        CHECK( -0.70971680 == Approx( linear.y()[13] ) );
+        CHECK( -0.43945313 == Approx( linear.y()[14] ) );
+        CHECK( -0.31723023 == Approx( linear.y()[15] ) );
+        CHECK( -0.20336914 == Approx( linear.y()[16] ) );
+        CHECK( -0.09768677 == Approx( linear.y()[17] ) );
+        CHECK( -0.04785538 == Approx( linear.y()[18] ) );
+        CHECK( -0.02368212 == Approx( linear.y()[19] ) );
+        CHECK(  0.0        == Approx( linear.y()[20] ) );
       } // THEN
 
       THEN( "arithmetic operations can be performed" ) {

--- a/src/scion/math/ChebyshevSeries/test/ChebyshevSeries.test.cpp
+++ b/src/scion/math/ChebyshevSeries/test/ChebyshevSeries.test.cpp
@@ -117,8 +117,8 @@ SCENARIO( "ChebyshevSeries" ) {
 
       THEN( "a PolynomialSeries can be linearised" ) {
 
-        ToleranceConvergence< double > tolerance( 0.01 );
-        InterpolationTable< double > linear = chunk.linearise( tolerance );
+        ToleranceConvergence< double > convergence( 0.01 );
+        InterpolationTable< double > linear = chunk.linearise( convergence );
 
         CHECK( 21 == linear.numberPoints() );
         CHECK( 1 == linear.numberRegions() );

--- a/src/scion/math/InterpolationTable/test/InterpolationTable.test.cpp
+++ b/src/scion/math/InterpolationTable/test/InterpolationTable.test.cpp
@@ -47,7 +47,7 @@ SCENARIO( "InterpolationTable" ) {
         CHECK( true == std::holds_alternative< IntervalDomain< double > >( chunk.domain() ) );
       } // THEN
 
-      THEN( "a InterpolationTable can be evaluated" ) {
+      THEN( "an InterpolationTable can be evaluated" ) {
 
         // values of x in the x grid
         CHECK( 4. == Approx( chunk( 1. ) ) );
@@ -65,7 +65,7 @@ SCENARIO( "InterpolationTable" ) {
         CHECK( 1.5 == Approx( chunk( 3.5 ) ) );
       } // THEN
 
-      THEN( "a InterpolationTable can be linearised" ) {
+      THEN( "an InterpolationTable can be linearised" ) {
 
         InterpolationTable< double > linear = chunk.linearise();
 
@@ -135,7 +135,7 @@ SCENARIO( "InterpolationTable" ) {
         CHECK( true == std::holds_alternative< IntervalDomain< double > >( chunk.domain() ) );
       } // THEN
 
-      THEN( "a InterpolationTable can be evaluated" ) {
+      THEN( "an InterpolationTable can be evaluated" ) {
 
         // values of x in the x grid
         CHECK( 4. == Approx( chunk( 1. ) ) );
@@ -155,7 +155,7 @@ SCENARIO( "InterpolationTable" ) {
         CHECK( 1.464163065 == Approx( chunk( 3.5 ) ) );
       } // THEN
 
-      THEN( "a InterpolationTable can be linearised" ) {
+      THEN( "an InterpolationTable can be linearised" ) {
 
         InterpolationTable< double > linear = chunk.linearise();
 

--- a/src/scion/math/LegendreSeries/test/LegendreSeries.test.cpp
+++ b/src/scion/math/LegendreSeries/test/LegendreSeries.test.cpp
@@ -117,8 +117,8 @@ SCENARIO( "LegendreSeries" ) {
 
       THEN( "a PolynomialSeries can be linearised" ) {
 
-        ToleranceConvergence< double > tolerance( 0.01 );
-        InterpolationTable< double > linear = chunk.linearise( tolerance );
+        ToleranceConvergence< double > convergence( 0.01 );
+        InterpolationTable< double > linear = chunk.linearise( convergence );
 
         CHECK( 21 == linear.numberPoints() );
         CHECK( 1 == linear.numberRegions() );

--- a/src/scion/math/LegendreSeries/test/LegendreSeries.test.cpp
+++ b/src/scion/math/LegendreSeries/test/LegendreSeries.test.cpp
@@ -9,6 +9,12 @@
 using namespace njoy::scion;
 template < typename X, typename Y = X > using LegendreSeries = math::LegendreSeries< X, Y >;
 template < typename X > using IntervalDomain = math::IntervalDomain< X >;
+template < typename X, typename Y = X >
+using InterpolationTable = math::InterpolationTable< X, Y >;
+template < typename X > using IntervalDomain = math::IntervalDomain< X >;
+using InterpolationType = interpolation::InterpolationType;
+template< typename X, typename Y = X >
+using ToleranceConvergence = linearisation::ToleranceConvergence< X, Y >;
 
 SCENARIO( "LegendreSeries" ) {
 
@@ -107,6 +113,68 @@ SCENARIO( "LegendreSeries" ) {
 
         CHECK( 1 == roots.size() );
         CHECK(  0.0 == Approx( roots[0] ) );
+      } // THEN
+
+      THEN( "a PolynomialSeries can be linearised" ) {
+
+        ToleranceConvergence< double > tolerance( 0.01 );
+        InterpolationTable< double > linear = chunk.linearise( tolerance );
+
+        CHECK( 21 == linear.numberPoints() );
+        CHECK( 1 == linear.numberRegions() );
+
+        CHECK( 21 == linear.x().size() );
+        CHECK( 21 == linear.y().size() );
+        CHECK( 1 == linear.boundaries().size() );
+        CHECK( 1 == linear.interpolants().size() );
+
+        CHECK( 20 == linear.boundaries()[0] );
+
+        CHECK( InterpolationType::LinearLinear == linear.interpolants()[0] );
+
+        CHECK( -1.0       == Approx( linear.x()[0] ) );
+        CHECK( -0.75      == Approx( linear.x()[1] ) );
+        CHECK( -0.5       == Approx( linear.x()[2] ) );
+        CHECK( -0.25      == Approx( linear.x()[3] ) );
+        CHECK( -0.125     == Approx( linear.x()[4] ) );
+        CHECK(  0.0       == Approx( linear.x()[5] ) );
+        CHECK(  0.125     == Approx( linear.x()[6] ) );
+        CHECK(  0.25      == Approx( linear.x()[7] ) );
+        CHECK(  0.375     == Approx( linear.x()[8] ) );
+        CHECK(  0.5       == Approx( linear.x()[9] ) );
+        CHECK(  0.625     == Approx( linear.x()[10] ) );
+        CHECK(  0.6875    == Approx( linear.x()[11] ) );
+        CHECK(  0.75      == Approx( linear.x()[12] ) );
+        CHECK(  0.8125    == Approx( linear.x()[13] ) );
+        CHECK(  0.875     == Approx( linear.x()[14] ) );
+        CHECK(  0.90625   == Approx( linear.x()[15] ) );
+        CHECK(  0.9375    == Approx( linear.x()[16] ) );
+        CHECK(  0.96875   == Approx( linear.x()[17] ) );
+        CHECK(  0.984375  == Approx( linear.x()[18] ) );
+        CHECK(  0.9921875 == Approx( linear.x()[19] ) );
+        CHECK(  1.0       == Approx( linear.x()[20] ) );
+
+        CHECK( -30.0       == Approx( linear.y()[0] ) );
+        CHECK( -22.859375  == Approx( linear.y()[1] ) );
+        CHECK( -16.875     == Approx( linear.y()[2] ) );
+        CHECK( -11.953125  == Approx( linear.y()[3] ) );
+        CHECK( -9.86132813 == Approx( linear.y()[4] ) );
+        CHECK( -8.0        == Approx( linear.y()[5] ) );
+        CHECK( -6.35742188 == Approx( linear.y()[6] ) );
+        CHECK( -4.921875   == Approx( linear.y()[7] ) );
+        CHECK( -3.68164063 == Approx( linear.y()[8] ) );
+        CHECK( -2.625      == Approx( linear.y()[9] ) );
+        CHECK( -1.74023438 == Approx( linear.y()[10] ) );
+        CHECK( -1.35864258 == Approx( linear.y()[11] ) );
+        CHECK( -1.015625   == Approx( linear.y()[12] ) );
+        CHECK( -0.70971680 == Approx( linear.y()[13] ) );
+        CHECK( -0.43945313 == Approx( linear.y()[14] ) );
+        CHECK( -0.31723023 == Approx( linear.y()[15] ) );
+        CHECK( -0.20336914 == Approx( linear.y()[16] ) );
+        CHECK( -0.09768677 == Approx( linear.y()[17] ) );
+        CHECK( -0.04785538 == Approx( linear.y()[18] ) );
+        CHECK( -0.02368212 == Approx( linear.y()[19] ) );
+        CHECK(  0.0        == Approx( linear.y()[20] ) );
       } // THEN
 
       THEN( "arithmetic operations can be performed" ) {

--- a/src/scion/math/PolynomialSeries/test/PolynomialSeries.test.cpp
+++ b/src/scion/math/PolynomialSeries/test/PolynomialSeries.test.cpp
@@ -135,8 +135,8 @@ SCENARIO( "PolynomialSeries" ) {
 
       THEN( "a PolynomialSeries can be linearised" ) {
 
-        ToleranceConvergence< double > tolerance( 0.01 );
-        InterpolationTable< double > linear = chunk.linearise( tolerance );
+        ToleranceConvergence< double > convergence( 0.01 );
+        InterpolationTable< double > linear = chunk.linearise( convergence );
 
         CHECK( 21 == linear.numberPoints() );
         CHECK( 1 == linear.numberRegions() );

--- a/src/scion/math/PolynomialSeries/test/PolynomialSeries.test.cpp
+++ b/src/scion/math/PolynomialSeries/test/PolynomialSeries.test.cpp
@@ -9,6 +9,12 @@
 using namespace njoy::scion;
 template < typename X, typename Y = X > using PolynomialSeries = math::PolynomialSeries< X, Y >;
 template < typename X > using IntervalDomain = math::IntervalDomain< X >;
+template < typename X, typename Y = X >
+using InterpolationTable = math::InterpolationTable< X, Y >;
+template < typename X > using IntervalDomain = math::IntervalDomain< X >;
+using InterpolationType = interpolation::InterpolationType;
+template< typename X, typename Y = X >
+using ToleranceConvergence = linearisation::ToleranceConvergence< X, Y >;
 
 SCENARIO( "PolynomialSeries" ) {
 
@@ -125,6 +131,68 @@ SCENARIO( "PolynomialSeries" ) {
 
         CHECK( 1 == roots.size() );
         CHECK(  0.0 == Approx( roots[0] ) );
+      } // THEN
+
+      THEN( "a PolynomialSeries can be linearised" ) {
+
+        ToleranceConvergence< double > tolerance( 0.01 );
+        InterpolationTable< double > linear = chunk.linearise( tolerance );
+
+        CHECK( 21 == linear.numberPoints() );
+        CHECK( 1 == linear.numberRegions() );
+
+        CHECK( 21 == linear.x().size() );
+        CHECK( 21 == linear.y().size() );
+        CHECK( 1 == linear.boundaries().size() );
+        CHECK( 1 == linear.interpolants().size() );
+
+        CHECK( 20 == linear.boundaries()[0] );
+
+        CHECK( InterpolationType::LinearLinear == linear.interpolants()[0] );
+
+        CHECK( -1.0       == Approx( linear.x()[0] ) );
+        CHECK( -0.75      == Approx( linear.x()[1] ) );
+        CHECK( -0.5       == Approx( linear.x()[2] ) );
+        CHECK( -0.25      == Approx( linear.x()[3] ) );
+        CHECK( -0.125     == Approx( linear.x()[4] ) );
+        CHECK(  0.0       == Approx( linear.x()[5] ) );
+        CHECK(  0.125     == Approx( linear.x()[6] ) );
+        CHECK(  0.25      == Approx( linear.x()[7] ) );
+        CHECK(  0.375     == Approx( linear.x()[8] ) );
+        CHECK(  0.5       == Approx( linear.x()[9] ) );
+        CHECK(  0.625     == Approx( linear.x()[10] ) );
+        CHECK(  0.6875    == Approx( linear.x()[11] ) );
+        CHECK(  0.75      == Approx( linear.x()[12] ) );
+        CHECK(  0.8125    == Approx( linear.x()[13] ) );
+        CHECK(  0.875     == Approx( linear.x()[14] ) );
+        CHECK(  0.90625   == Approx( linear.x()[15] ) );
+        CHECK(  0.9375    == Approx( linear.x()[16] ) );
+        CHECK(  0.96875   == Approx( linear.x()[17] ) );
+        CHECK(  0.984375  == Approx( linear.x()[18] ) );
+        CHECK(  0.9921875 == Approx( linear.x()[19] ) );
+        CHECK(  1.0       == Approx( linear.x()[20] ) );
+
+        CHECK( -30.0       == Approx( linear.y()[0] ) );
+        CHECK( -22.859375  == Approx( linear.y()[1] ) );
+        CHECK( -16.875     == Approx( linear.y()[2] ) );
+        CHECK( -11.953125  == Approx( linear.y()[3] ) );
+        CHECK( -9.86132813 == Approx( linear.y()[4] ) );
+        CHECK( -8.0        == Approx( linear.y()[5] ) );
+        CHECK( -6.35742188 == Approx( linear.y()[6] ) );
+        CHECK( -4.921875   == Approx( linear.y()[7] ) );
+        CHECK( -3.68164063 == Approx( linear.y()[8] ) );
+        CHECK( -2.625      == Approx( linear.y()[9] ) );
+        CHECK( -1.74023438 == Approx( linear.y()[10] ) );
+        CHECK( -1.35864258 == Approx( linear.y()[11] ) );
+        CHECK( -1.015625   == Approx( linear.y()[12] ) );
+        CHECK( -0.70971680 == Approx( linear.y()[13] ) );
+        CHECK( -0.43945313 == Approx( linear.y()[14] ) );
+        CHECK( -0.31723023 == Approx( linear.y()[15] ) );
+        CHECK( -0.20336914 == Approx( linear.y()[16] ) );
+        CHECK( -0.09768677 == Approx( linear.y()[17] ) );
+        CHECK( -0.04785538 == Approx( linear.y()[18] ) );
+        CHECK( -0.02368212 == Approx( linear.y()[19] ) );
+        CHECK(  0.0        == Approx( linear.y()[20] ) );
       } // THEN
 
       THEN( "arithmetic operations can be performed" ) {


### PR DESCRIPTION
Added linearisation tests for the various series (except for ChebyshevApproximation) since these seemed to be missing

The test was performed for a 1% linearisation since the default (0.1%) generates a grid of 66 points versus 21 points for 1%.

Tests were added for both C++ and Python