### PR TITLE
Feature/domain comparisons

### DIFF
--- a/python/src/definitions.hpp
+++ b/python/src/definitions.hpp
@@ -43,6 +43,20 @@ void addStandardDomainDefinitions( PythonClass& component ) {
     "Arguments:\n"
     "    self   the domain\n"
     "    x      the value to be tested"
+  )
+  .def(
+
+    "__eq__",
+    [] ( const Component& self, const Component& right )
+       { return self == right; },
+    python::is_operator()
+  )
+  .def(
+
+    "__ne__",
+    [] ( const Component& self, const Component& right )
+       { return self != right; },
+    python::is_operator()
   );
 }
 

--- a/python/src/definitions.hpp
+++ b/python/src/definitions.hpp
@@ -8,6 +8,7 @@
 
 // other includes
 #include "scion/linearisation/ToleranceConvergence.hpp"
+#include "scion/math/FunctionBase.hpp"
 
 // namespace aliases
 namespace python = pybind11;
@@ -72,6 +73,10 @@ template < typename Component, typename X, typename Y, typename PythonClass >
 void addStandardFunctionDefinitions( PythonClass& component ) {
 
   using ToleranceConvergence = njoy::scion::linearisation::ToleranceConvergence< X, Y >;
+  using DomainVariant = typename njoy::scion::math::FunctionBase< X, Y >::DomainVariant;
+
+  // note: for is_same_domain to bind properly, all possible variant members
+  //       must have a default constructor
 
   component
   .def_property_readonly(
@@ -124,6 +129,17 @@ void addStandardFunctionDefinitions( PythonClass& component ) {
     "Arguments:\n"
     "    self           the function\n"
     "    convergence    the linearisation convergence criterion (default 0.1 %)"
+  )
+  .def(
+
+    "is_same_domain",
+    [] ( const Component& self, const DomainVariant& domain )
+       { return self.isSameDomain( domain ); },
+    python::arg( "domain" ),
+    "Check whether or not a domain is equal to the function's domain\n\n"
+    "Arguments:\n"
+    "    self     the function\n"
+    "    domain   the domain to be tested"
   );
 }
 

--- a/python/test/math/Test_scion_math_ChebyshevApproximation.py
+++ b/python/test/math/Test_scion_math_ChebyshevApproximation.py
@@ -7,6 +7,7 @@ import sys
 # local imports
 from scion.math import ChebyshevApproximation
 from scion.math import IntervalDomain
+from scion.math import OpenDomain
 
 class Test_scion_math_ChebyshevApproximation( unittest.TestCase ) :
     """Unit test for the ChebyshevApproximation class."""
@@ -66,6 +67,19 @@ class Test_scion_math_ChebyshevApproximation( unittest.TestCase ) :
             self.assertAlmostEqual( +0.999999 , chunk(  0.999999 ) )
             self.assertAlmostEqual( +0.9999999, chunk(  0.9999999 ) )
             self.assertAlmostEqual( +1.0      , chunk(  1. ) )
+
+            # verify domain comparison
+            self.assertEqual( True, chunk.is_inside( -1. ) )
+            self.assertEqual( True, chunk.is_inside(  0. ) )
+            self.assertEqual( True, chunk.is_inside(  1. ) )
+
+            self.assertEqual( False, chunk.is_contained( -1. ) )
+            self.assertEqual( True, chunk.is_contained(  0. ) )
+            self.assertEqual( False, chunk.is_contained(  1. ) )
+
+            self.assertEqual( True, chunk.is_same_domain( IntervalDomain( -1., 1. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( IntervalDomain( 0., 1. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( OpenDomain() ) )
 
             # verify arithmetic operators
             small = ChebyshevApproximation( -1, 1, [ 3., 0., 1. ] )
@@ -328,6 +342,19 @@ class Test_scion_math_ChebyshevApproximation( unittest.TestCase ) :
             self.assertAlmostEqual( +0.999999 , chunk(  0.999999 ) )
             self.assertAlmostEqual( +0.9999999, chunk(  0.9999999 ) )
             self.assertAlmostEqual( +1.0      , chunk(  1. ) )
+
+            # verify domain comparison
+            self.assertEqual( True, chunk.is_inside( -2. ) )
+            self.assertEqual( True, chunk.is_inside(  1. ) )
+            self.assertEqual( True, chunk.is_inside(  4. ) )
+
+            self.assertEqual( False, chunk.is_contained( -2. ) )
+            self.assertEqual( True, chunk.is_contained( 1. ) )
+            self.assertEqual( False, chunk.is_contained( 4. ) )
+
+            self.assertEqual( True, chunk.is_same_domain( IntervalDomain( -2., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( IntervalDomain( 0., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( OpenDomain() ) )
 
             # verify arithmetic operators
             small = ChebyshevApproximation( -2, 4, [ 3., 0., 1. ] )

--- a/python/test/math/Test_scion_math_ChebyshevSeries.py
+++ b/python/test/math/Test_scion_math_ChebyshevSeries.py
@@ -7,6 +7,7 @@ import sys
 # local imports
 from scion.math import ChebyshevSeries
 from scion.math import IntervalDomain
+from scion.math import OpenDomain
 from scion.linearisation import ToleranceConvergence
 from scion.interpolation import InterpolationType
 
@@ -89,6 +90,19 @@ class Test_scion_math_ChebyshevSeries( unittest.TestCase ) :
             roots = chunk.roots( -8. )
             self.assertEqual( 1, len( roots ) )
             self.assertAlmostEqual( 0.0, roots[0] )
+
+            # verify domain comparison
+            self.assertEqual( True, chunk.is_inside( -1. ) )
+            self.assertEqual( True, chunk.is_inside(  0. ) )
+            self.assertEqual( True, chunk.is_inside(  1. ) )
+
+            self.assertEqual( False, chunk.is_contained( -1. ) )
+            self.assertEqual( True, chunk.is_contained(  0. ) )
+            self.assertEqual( False, chunk.is_contained(  1. ) )
+
+            self.assertEqual( True, chunk.is_same_domain( IntervalDomain( -1., 1. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( IntervalDomain( 0., 1. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( OpenDomain() ) )
 
             # verify linearisation
             convergence = ToleranceConvergence( 0.01 )

--- a/python/test/math/Test_scion_math_HistogramTable.py
+++ b/python/test/math/Test_scion_math_HistogramTable.py
@@ -7,6 +7,7 @@ import sys
 # local imports
 from scion.math import HistogramTable
 from scion.math import IntervalDomain
+from scion.math import OpenDomain
 from scion.interpolation import InterpolationType
 
 class Test_scion_math_HistogramTable( unittest.TestCase ) :
@@ -44,6 +45,19 @@ class Test_scion_math_HistogramTable( unittest.TestCase ) :
             self.assertAlmostEqual( 4., chunk( x = 1.5 ) )
             self.assertAlmostEqual( 3., chunk( x = 2.5 ) )
             self.assertAlmostEqual( 2., chunk( x = 3.5 ) )
+
+            # verify domain comparison
+            self.assertEqual( True, chunk.is_inside( 1. ) )
+            self.assertEqual( True, chunk.is_inside( 2.5 ) )
+            self.assertEqual( True, chunk.is_inside( 4. ) )
+
+            self.assertEqual( False, chunk.is_contained( 1. ) )
+            self.assertEqual( True, chunk.is_contained( 2.5 ) )
+            self.assertEqual( False, chunk.is_contained( 4. ) )
+
+            self.assertEqual( True, chunk.is_same_domain( IntervalDomain( 1., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( IntervalDomain( 0., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( OpenDomain() ) )
 
             # verify linearisation
             linear = chunk.linearise()

--- a/python/test/math/Test_scion_math_InterpolationTable.py
+++ b/python/test/math/Test_scion_math_InterpolationTable.py
@@ -7,6 +7,7 @@ import sys
 # local imports
 from scion.math import InterpolationTable
 from scion.math import IntervalDomain
+from scion.math import OpenDomain
 from scion.interpolation import InterpolationType
 
 class Test_scion_math_InterpolationTable( unittest.TestCase ) :
@@ -48,6 +49,19 @@ class Test_scion_math_InterpolationTable( unittest.TestCase ) :
             self.assertAlmostEqual( 3.5, chunk( x = 1.5 ) )
             self.assertAlmostEqual( 2.5, chunk( x = 2.5 ) )
             self.assertAlmostEqual( 1.5, chunk( x = 3.5 ) )
+
+            # verify domain comparison
+            self.assertEqual( True, chunk.is_inside( 1. ) )
+            self.assertEqual( True, chunk.is_inside( 2.5 ) )
+            self.assertEqual( True, chunk.is_inside( 4. ) )
+
+            self.assertEqual( False, chunk.is_contained( 1. ) )
+            self.assertEqual( True, chunk.is_contained( 2.5 ) )
+            self.assertEqual( False, chunk.is_contained( 4. ) )
+
+            self.assertEqual( True, chunk.is_same_domain( IntervalDomain( 1., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( IntervalDomain( 0., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( OpenDomain() ) )
 
             # verify linearisation
             linear = chunk.linearise()
@@ -257,6 +271,19 @@ class Test_scion_math_InterpolationTable( unittest.TestCase ) :
             # verify evaluation - values of x inside the x grid (lin-lin piece)
             self.assertAlmostEqual( 2.449660287, chunk( x = 2.5 ) )
             self.assertAlmostEqual( 1.464163065, chunk( x = 3.5 ) )
+
+            # verify domain comparison
+            self.assertEqual( True, chunk.is_inside( 1. ) )
+            self.assertEqual( True, chunk.is_inside( 2.5 ) )
+            self.assertEqual( True, chunk.is_inside( 4. ) )
+
+            self.assertEqual( False, chunk.is_contained( 1. ) )
+            self.assertEqual( True, chunk.is_contained( 2.5 ) )
+            self.assertEqual( False, chunk.is_contained( 4. ) )
+
+            self.assertEqual( True, chunk.is_same_domain( IntervalDomain( 1., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( IntervalDomain( 0., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( OpenDomain() ) )
 
             # verify linearisation
             linear = chunk.linearise()
@@ -510,6 +537,19 @@ class Test_scion_math_InterpolationTable( unittest.TestCase ) :
             # verify evaluation - values of x inside the x grid (lin-lin piece)
             self.assertAlmostEqual( 3.449660287, chunk( x = 2.5 ) )
             self.assertAlmostEqual( 2.464163065, chunk( x = 3.5 ) )
+
+            # verify domain comparison
+            self.assertEqual( True, chunk.is_inside( 1. ) )
+            self.assertEqual( True, chunk.is_inside( 2.5 ) )
+            self.assertEqual( True, chunk.is_inside( 4. ) )
+
+            self.assertEqual( False, chunk.is_contained( 1. ) )
+            self.assertEqual( True, chunk.is_contained( 2.5 ) )
+            self.assertEqual( False, chunk.is_contained( 4. ) )
+
+            self.assertEqual( True, chunk.is_same_domain( IntervalDomain( 1., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( IntervalDomain( 0., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( OpenDomain() ) )
 
             # verify linearisation
             linear = chunk.linearise()

--- a/python/test/math/Test_scion_math_IntervalDomain.py
+++ b/python/test/math/Test_scion_math_IntervalDomain.py
@@ -22,21 +22,29 @@ class Test_scion_math_IntervalDomain( unittest.TestCase ) :
             max = sys.float_info.max
             min = -max
 
-            self.assertEqual( False, chunk.is_inside( x = min ) );
-            self.assertEqual( True, chunk.is_inside( x = -1.0 ) );
-            self.assertEqual( True, chunk.is_inside( x = -0.5 ) );
-            self.assertEqual( True, chunk.is_inside( x =  0.0 ) );
-            self.assertEqual( True, chunk.is_inside( x =  0.5 ) );
-            self.assertEqual( True, chunk.is_inside( x =  1.0 ) );
-            self.assertEqual( False, chunk.is_inside( x = max ) );
+            self.assertEqual( False, chunk.is_inside( x = min ) )
+            self.assertEqual( True, chunk.is_inside( x = -1.0 ) )
+            self.assertEqual( True, chunk.is_inside( x = -0.5 ) )
+            self.assertEqual( True, chunk.is_inside( x =  0.0 ) )
+            self.assertEqual( True, chunk.is_inside( x =  0.5 ) )
+            self.assertEqual( True, chunk.is_inside( x =  1.0 ) )
+            self.assertEqual( False, chunk.is_inside( x = max ) )
 
-            self.assertEqual( False, chunk.is_inside( x = min ) );
-            self.assertEqual( False, chunk.is_contained( x = -1.0 ) );
-            self.assertEqual( True, chunk.is_contained( x = -0.5 ) );
-            self.assertEqual( True, chunk.is_contained( x =  0.0 ) );
-            self.assertEqual( True, chunk.is_contained( x =  0.5 ) );
-            self.assertEqual( False, chunk.is_contained( x =  1.0 ) );
-            self.assertEqual( False, chunk.is_inside( x = max ) );
+            self.assertEqual( False, chunk.is_contained( x = min ) )
+            self.assertEqual( False, chunk.is_contained( x = -1.0 ) )
+            self.assertEqual( True, chunk.is_contained( x = -0.5 ) )
+            self.assertEqual( True, chunk.is_contained( x =  0.0 ) )
+            self.assertEqual( True, chunk.is_contained( x =  0.5 ) )
+            self.assertEqual( False, chunk.is_contained( x =  1.0 ) )
+            self.assertEqual( False, chunk.is_contained( x = max ) )
+
+            same = IntervalDomain( -1., 1. )
+            different = IntervalDomain( 0., 1. )
+
+            self.assertEqual( True, chunk == same )
+            self.assertEqual( False, chunk == different )
+            self.assertEqual( False, chunk != same )
+            self.assertEqual( True, chunk != different )
 
         # the data is given explicitly
         chunk = IntervalDomain( lower = -1., upper = 1. )

--- a/python/test/math/Test_scion_math_LegendreSeries.py
+++ b/python/test/math/Test_scion_math_LegendreSeries.py
@@ -7,6 +7,7 @@ import sys
 # local imports
 from scion.math import LegendreSeries
 from scion.math import IntervalDomain
+from scion.math import OpenDomain
 from scion.linearisation import ToleranceConvergence
 from scion.interpolation import InterpolationType
 
@@ -89,6 +90,19 @@ class Test_scion_math_LegendreSeries( unittest.TestCase ) :
             roots = chunk.roots( -8. )
             self.assertEqual( 1, len( roots ) )
             self.assertAlmostEqual( 0.0, roots[0] )
+
+            # verify domain comparison
+            self.assertEqual( True, chunk.is_inside( -1. ) )
+            self.assertEqual( True, chunk.is_inside(  0. ) )
+            self.assertEqual( True, chunk.is_inside(  1. ) )
+
+            self.assertEqual( False, chunk.is_contained( -1. ) )
+            self.assertEqual( True, chunk.is_contained(  0. ) )
+            self.assertEqual( False, chunk.is_contained(  1. ) )
+
+            self.assertEqual( True, chunk.is_same_domain( IntervalDomain( -1., 1. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( IntervalDomain( 0., 1. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( OpenDomain() ) )
 
             # verify linearisation
             convergence = ToleranceConvergence( 0.01 )

--- a/python/test/math/Test_scion_math_LinearLinearTable.py
+++ b/python/test/math/Test_scion_math_LinearLinearTable.py
@@ -7,6 +7,7 @@ import sys
 # local imports
 from scion.math import LinearLinearTable
 from scion.math import IntervalDomain
+from scion.math import OpenDomain
 from scion.interpolation import InterpolationType
 
 class Test_scion_math_LinearLinearTable( unittest.TestCase ) :
@@ -43,6 +44,19 @@ class Test_scion_math_LinearLinearTable( unittest.TestCase ) :
             # verify evaluation - values of x inside the x grid
             self.assertAlmostEqual( 3.5, chunk( x = 1.5 ) )
             self.assertAlmostEqual( 1.5, chunk( x = 3.5 ) )
+
+            # verify domain comparison
+            self.assertEqual( True, chunk.is_inside( 1. ) )
+            self.assertEqual( True, chunk.is_inside( 2.5 ) )
+            self.assertEqual( True, chunk.is_inside( 4. ) )
+
+            self.assertEqual( False, chunk.is_contained( 1. ) )
+            self.assertEqual( True, chunk.is_contained( 2.5 ) )
+            self.assertEqual( False, chunk.is_contained( 4. ) )
+
+            self.assertEqual( True, chunk.is_same_domain( IntervalDomain( 1., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( IntervalDomain( 0., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( OpenDomain() ) )
 
             # verify linearisation
             linear = chunk.linearise()

--- a/python/test/math/Test_scion_math_LinearLogTable.py
+++ b/python/test/math/Test_scion_math_LinearLogTable.py
@@ -7,6 +7,7 @@ import sys
 # local imports
 from scion.math import LinearLogTable
 from scion.math import IntervalDomain
+from scion.math import OpenDomain
 from scion.interpolation import InterpolationType
 
 class Test_scion_math_LinearLogTable( unittest.TestCase ) :
@@ -43,6 +44,19 @@ class Test_scion_math_LinearLogTable( unittest.TestCase ) :
             # verify evaluation - values of x inside the x grid
             self.assertAlmostEqual( 3.415037499, chunk( x = 1.5 ) )
             self.assertAlmostEqual( 1.464163065, chunk( x = 3.5 ) )
+
+            # verify domain comparison
+            self.assertEqual( True, chunk.is_inside( 1. ) )
+            self.assertEqual( True, chunk.is_inside( 2.5 ) )
+            self.assertEqual( True, chunk.is_inside( 4. ) )
+
+            self.assertEqual( False, chunk.is_contained( 1. ) )
+            self.assertEqual( True, chunk.is_contained( 2.5 ) )
+            self.assertEqual( False, chunk.is_contained( 4. ) )
+
+            self.assertEqual( True, chunk.is_same_domain( IntervalDomain( 1., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( IntervalDomain( 0., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( OpenDomain() ) )
 
             # verify linearisation
             linear = chunk.linearise()

--- a/python/test/math/Test_scion_math_LogLinearTable.py
+++ b/python/test/math/Test_scion_math_LogLinearTable.py
@@ -7,6 +7,7 @@ import sys
 # local imports
 from scion.math import LogLinearTable
 from scion.math import IntervalDomain
+from scion.math import OpenDomain
 from scion.interpolation import InterpolationType
 
 class Test_scion_math_LogLinearTable( unittest.TestCase ) :
@@ -43,6 +44,19 @@ class Test_scion_math_LogLinearTable( unittest.TestCase ) :
             # verify evaluation - values of x inside the x grid
             self.assertAlmostEqual( 3.464101615, chunk( x = 1.5 ) )
             self.assertAlmostEqual( 1.414213562, chunk( x = 3.5 ) )
+
+            # verify domain comparison
+            self.assertEqual( True, chunk.is_inside( 1. ) )
+            self.assertEqual( True, chunk.is_inside( 2.5 ) )
+            self.assertEqual( True, chunk.is_inside( 4. ) )
+
+            self.assertEqual( False, chunk.is_contained( 1. ) )
+            self.assertEqual( True, chunk.is_contained( 2.5 ) )
+            self.assertEqual( False, chunk.is_contained( 4. ) )
+
+            self.assertEqual( True, chunk.is_same_domain( IntervalDomain( 1., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( IntervalDomain( 0., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( OpenDomain() ) )
 
             # verify linearisation
             linear = chunk.linearise()

--- a/python/test/math/Test_scion_math_LogLogTable.py
+++ b/python/test/math/Test_scion_math_LogLogTable.py
@@ -7,6 +7,7 @@ import sys
 # local imports
 from scion.math import LogLogTable
 from scion.math import IntervalDomain
+from scion.math import OpenDomain
 from scion.interpolation import InterpolationType
 
 class Test_scion_math_LogLogTable( unittest.TestCase ) :
@@ -43,6 +44,19 @@ class Test_scion_math_LogLogTable( unittest.TestCase ) :
             # verify evaluation - values of x inside the x grid
             self.assertAlmostEqual( 3.380457775, chunk( x = 1.5 ) )
             self.assertAlmostEqual( 1.379516838, chunk( x = 3.5 ) )
+
+            # verify domain comparison
+            self.assertEqual( True, chunk.is_inside( 1. ) )
+            self.assertEqual( True, chunk.is_inside( 2.5 ) )
+            self.assertEqual( True, chunk.is_inside( 4. ) )
+
+            self.assertEqual( False, chunk.is_contained( 1. ) )
+            self.assertEqual( True, chunk.is_contained( 2.5 ) )
+            self.assertEqual( False, chunk.is_contained( 4. ) )
+
+            self.assertEqual( True, chunk.is_same_domain( IntervalDomain( 1., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( IntervalDomain( 0., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( OpenDomain() ) )
 
             # verify linearisation
             linear = chunk.linearise()

--- a/python/test/math/Test_scion_math_OpenDomain.py
+++ b/python/test/math/Test_scion_math_OpenDomain.py
@@ -18,21 +18,26 @@ class Test_scion_math_OpenDomain( unittest.TestCase ) :
             max = sys.float_info.max
             min = -max
 
-            self.assertEqual( True, chunk.is_inside( x = min ) );
-            self.assertEqual( True, chunk.is_inside( x = -1.0 ) );
-            self.assertEqual( True, chunk.is_inside( x = -0.5 ) );
-            self.assertEqual( True, chunk.is_inside( x =  0.0 ) );
-            self.assertEqual( True, chunk.is_inside( x =  0.5 ) );
-            self.assertEqual( True, chunk.is_inside( x =  1.0 ) );
-            self.assertEqual( True, chunk.is_inside( x = max ) );
+            self.assertEqual( True, chunk.is_inside( x = min ) )
+            self.assertEqual( True, chunk.is_inside( x = -1.0 ) )
+            self.assertEqual( True, chunk.is_inside( x = -0.5 ) )
+            self.assertEqual( True, chunk.is_inside( x =  0.0 ) )
+            self.assertEqual( True, chunk.is_inside( x =  0.5 ) )
+            self.assertEqual( True, chunk.is_inside( x =  1.0 ) )
+            self.assertEqual( True, chunk.is_inside( x = max ) )
 
-            self.assertEqual( True, chunk.is_inside( x = min ) );
-            self.assertEqual( True, chunk.is_contained( x = -1.0 ) );
-            self.assertEqual( True, chunk.is_contained( x = -0.5 ) );
-            self.assertEqual( True, chunk.is_contained( x =  0.0 ) );
-            self.assertEqual( True, chunk.is_contained( x =  0.5 ) );
-            self.assertEqual( True, chunk.is_contained( x =  1.0 ) );
-            self.assertEqual( True, chunk.is_inside( x = max ) );
+            self.assertEqual( True, chunk.is_contained( x = min ) )
+            self.assertEqual( True, chunk.is_contained( x = -1.0 ) )
+            self.assertEqual( True, chunk.is_contained( x = -0.5 ) )
+            self.assertEqual( True, chunk.is_contained( x =  0.0 ) )
+            self.assertEqual( True, chunk.is_contained( x =  0.5 ) )
+            self.assertEqual( True, chunk.is_contained( x =  1.0 ) )
+            self.assertEqual( True, chunk.is_contained( x = max ) )
+
+            same = OpenDomain()
+
+            self.assertEqual( True, chunk == same )
+            self.assertEqual( False, chunk != same )
 
         # the data is given explicitly
         chunk = OpenDomain()

--- a/python/test/math/Test_scion_math_PolynomialSeries.py
+++ b/python/test/math/Test_scion_math_PolynomialSeries.py
@@ -7,6 +7,7 @@ import sys
 # local imports
 from scion.math import PolynomialSeries
 from scion.math import IntervalDomain
+from scion.math import OpenDomain
 from scion.linearisation import ToleranceConvergence
 from scion.interpolation import InterpolationType
 
@@ -107,6 +108,19 @@ class Test_scion_math_PolynomialSeries( unittest.TestCase ) :
             roots = chunk.roots( -8. )
             self.assertEqual( 1, len( roots ) )
             self.assertAlmostEqual( 0.0, roots[0] )
+
+            # verify domain comparison
+            self.assertEqual( True, chunk.is_inside( -1. ) )
+            self.assertEqual( True, chunk.is_inside(  0. ) )
+            self.assertEqual( True, chunk.is_inside(  1. ) )
+
+            self.assertEqual( False, chunk.is_contained( -1. ) )
+            self.assertEqual( True, chunk.is_contained(  0. ) )
+            self.assertEqual( False, chunk.is_contained(  1. ) )
+
+            self.assertEqual( True, chunk.is_same_domain( IntervalDomain( -1., 1. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( IntervalDomain( 0., 1. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( OpenDomain() ) )
 
             # verify linearisation
             convergence = ToleranceConvergence( 0.01 )

--- a/src/scion/math/ChebyshevApproximation.hpp
+++ b/src/scion/math/ChebyshevApproximation.hpp
@@ -236,6 +236,7 @@ namespace math {
     using Parent::operator();
     using Parent::isInside;
     using Parent::isContained;
+    using Parent::isSameDomain;
   };
 
 } // math namespace

--- a/src/scion/math/ChebyshevApproximation/test/ChebyshevApproximation.test.cpp
+++ b/src/scion/math/ChebyshevApproximation/test/ChebyshevApproximation.test.cpp
@@ -9,6 +9,7 @@
 using namespace njoy::scion;
 template < typename X, typename Y = X > using ChebyshevApproximation = math::ChebyshevApproximation< X, Y >;
 template < typename X > using IntervalDomain = math::IntervalDomain< X >;
+template < typename X > using OpenDomain = math::OpenDomain< X >;
 
 SCENARIO( "ChebyshevApproximation" ) {
 
@@ -74,6 +75,21 @@ SCENARIO( "ChebyshevApproximation" ) {
         CHECK( +0.999999  == Approx( chunk(  0.999999 ) ) );
         CHECK( +0.9999999 == Approx( chunk(  0.9999999 ) ) );
         CHECK( +1.0       == Approx( chunk(  1. ) ) );
+      } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( -1. ) );
+        CHECK( true == chunk.isInside(  0. ) );
+        CHECK( true == chunk.isInside(  1. ) );
+
+        CHECK( false == chunk.isContained( -1. ) );
+        CHECK( true == chunk.isContained( 0. ) );
+        CHECK( false == chunk.isContained( 1. ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( -1., 1. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 1. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
       } // THEN
 
       THEN( "arithmetic operations can be performed" ) {
@@ -336,6 +352,21 @@ SCENARIO( "ChebyshevApproximation" ) {
         CHECK( +0.999999  == Approx( chunk(  0.999999 ) ) );
         CHECK( +0.9999999 == Approx( chunk(  0.9999999 ) ) );
         CHECK( +1.0       == Approx( chunk(  1. ) ) );
+      } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( -2. ) );
+        CHECK( true == chunk.isInside(  1. ) );
+        CHECK( true == chunk.isInside(  4. ) );
+
+        CHECK( false == chunk.isContained( -2. ) );
+        CHECK( true == chunk.isContained( 1. ) );
+        CHECK( false == chunk.isContained( 4. ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( -2., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
       } // THEN
 
       THEN( "arithmetic operations can be performed" ) {

--- a/src/scion/math/ChebyshevSeries.hpp
+++ b/src/scion/math/ChebyshevSeries.hpp
@@ -85,6 +85,7 @@ namespace math {
     using Parent::operator();
     using Parent::isInside;
     using Parent::isContained;
+    using Parent::isSameDomain;
   };
 
 } // math namespace

--- a/src/scion/math/ChebyshevSeries/test/ChebyshevSeries.test.cpp
+++ b/src/scion/math/ChebyshevSeries/test/ChebyshevSeries.test.cpp
@@ -9,6 +9,7 @@
 using namespace njoy::scion;
 template < typename X, typename Y = X > using ChebyshevSeries = math::ChebyshevSeries< X, Y >;
 template < typename X > using IntervalDomain = math::IntervalDomain< X >;
+template < typename X > using OpenDomain = math::OpenDomain< X >;
 template < typename X, typename Y = X >
 using InterpolationTable = math::InterpolationTable< X, Y >;
 template < typename X > using IntervalDomain = math::IntervalDomain< X >;
@@ -63,6 +64,21 @@ SCENARIO( "ChebyshevSeries" ) {
 
         CHECK( 1 == roots.size() );
         CHECK(  0.0 == Approx( roots[0] ) );
+      } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( -1. ) );
+        CHECK( true == chunk.isInside(  0. ) );
+        CHECK( true == chunk.isInside(  1. ) );
+
+        CHECK( false == chunk.isContained( -1. ) );
+        CHECK( true == chunk.isContained( 0. ) );
+        CHECK( false == chunk.isContained( 1. ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( -1., 1. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 1. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
       } // THEN
 
       THEN( "a ChebyshevSeries can be differentiated" ) {

--- a/src/scion/math/FunctionBase.hpp
+++ b/src/scion/math/FunctionBase.hpp
@@ -89,6 +89,16 @@ namespace math {
                               { return domain.isContained( x ); },
                          this->domain() );
     }
+
+    /**
+     *  @brief Check whether or not a domain is equal to the function's domain
+     *
+     *  @param domain   the domain to be tested
+     */
+    bool isSameDomain( const DomainVariant& domain ) const noexcept {
+
+      return this->domain() == domain;
+    }
   };
 
 } // math namespace

--- a/src/scion/math/HistogramTable.hpp
+++ b/src/scion/math/HistogramTable.hpp
@@ -97,6 +97,7 @@ namespace math {
     using Parent::operator();
     using Parent::isInside;
     using Parent::isContained;
+    using Parent::isSameDomain;
   };
 
 } // math namespace

--- a/src/scion/math/HistogramTable/test/HistogramTable.test.cpp
+++ b/src/scion/math/HistogramTable/test/HistogramTable.test.cpp
@@ -12,6 +12,7 @@ template < typename X, typename Y = X,
            typename XContainer = std::vector< X >,
            typename YContainer = std::vector< Y > >
 using HistogramTable = math::HistogramTable< X, Y, XContainer, YContainer >;
+template < typename X > using OpenDomain = math::OpenDomain< X >;
 template < typename X > using IntervalDomain = math::IntervalDomain< X >;
 using InterpolationType = interpolation::InterpolationType;
 
@@ -60,6 +61,21 @@ SCENARIO( "HistogramTable" ) {
         CHECK( 4. == Approx( chunk( 1.5 ) ) );
         CHECK( 3. == Approx( chunk( 2.5 ) ) );
         CHECK( 2. == Approx( chunk( 3.5 ) ) );
+      } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( 1.0 ) );
+        CHECK( true == chunk.isInside( 2.5 ) );
+        CHECK( true == chunk.isInside( 4.0 ) );
+
+        CHECK( false == chunk.isContained( 1.0 ) );
+        CHECK( true == chunk.isContained( 2.5 ) );
+        CHECK( false == chunk.isContained( 4.0 ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( 1., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
       } // THEN
 
       THEN( "a HistogramTable can be linearised" ) {
@@ -130,6 +146,21 @@ SCENARIO( "HistogramTable" ) {
         CHECK( 4. == Approx( chunk( 1.5 ) ) );
         CHECK( 3. == Approx( chunk( 2.5 ) ) );
         CHECK( 2. == Approx( chunk( 3.5 ) ) );
+      } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( 1.0 ) );
+        CHECK( true == chunk.isInside( 2.5 ) );
+        CHECK( true == chunk.isInside( 4.0 ) );
+
+        CHECK( false == chunk.isContained( 1.0 ) );
+        CHECK( true == chunk.isContained( 2.5 ) );
+        CHECK( false == chunk.isContained( 4.0 ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( 1., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
       } // THEN
 
       THEN( "a HistogramTable can be linearised" ) {

--- a/src/scion/math/InterpolationTable.hpp
+++ b/src/scion/math/InterpolationTable.hpp
@@ -212,6 +212,7 @@ namespace math {
     using Parent::operator();
     using Parent::isInside;
     using Parent::isContained;
+    using Parent::isSameDomain;
   };
 
 } // math namespace

--- a/src/scion/math/InterpolationTable/test/InterpolationTable.test.cpp
+++ b/src/scion/math/InterpolationTable/test/InterpolationTable.test.cpp
@@ -10,6 +10,7 @@ using namespace njoy::scion;
 template < typename X, typename Y = X >
 using InterpolationTable = math::InterpolationTable< X, Y >;
 template < typename X > using IntervalDomain = math::IntervalDomain< X >;
+template < typename X > using OpenDomain = math::OpenDomain< X >;
 using InterpolationType = interpolation::InterpolationType;
 
 SCENARIO( "InterpolationTable" ) {
@@ -62,6 +63,21 @@ SCENARIO( "InterpolationTable" ) {
         CHECK( 3.5 == Approx( chunk( 1.5 ) ) );
         CHECK( 2.5 == Approx( chunk( 2.5 ) ) );
         CHECK( 1.5 == Approx( chunk( 3.5 ) ) );
+      } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( 1.0 ) );
+        CHECK( true == chunk.isInside( 2.5 ) );
+        CHECK( true == chunk.isInside( 4.0 ) );
+
+        CHECK( false == chunk.isContained( 1.0 ) );
+        CHECK( true == chunk.isContained( 2.5 ) );
+        CHECK( false == chunk.isContained( 4.0 ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( 1., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
       } // THEN
 
       THEN( "arithmetic operations can be performed" ) {
@@ -317,6 +333,21 @@ SCENARIO( "InterpolationTable" ) {
         // values of x inside the x grid (lin-log piece)
         CHECK( 2.449660287 == Approx( chunk( 2.5 ) ) );
         CHECK( 1.464163065 == Approx( chunk( 3.5 ) ) );
+      } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( 1.0 ) );
+        CHECK( true == chunk.isInside( 2.5 ) );
+        CHECK( true == chunk.isInside( 4.0 ) );
+
+        CHECK( false == chunk.isContained( 1.0 ) );
+        CHECK( true == chunk.isContained( 2.5 ) );
+        CHECK( false == chunk.isContained( 4.0 ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( 1., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
       } // THEN
 
       THEN( "an InterpolationTable can be linearised" ) {
@@ -616,6 +647,21 @@ SCENARIO( "InterpolationTable" ) {
         // values of x inside the x grid (lin-log piece)
         CHECK( 3.449660287 == Approx( chunk( 2.5 ) ) );
         CHECK( 2.464163065 == Approx( chunk( 3.5 ) ) );
+      } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( 1.0 ) );
+        CHECK( true == chunk.isInside( 2.5 ) );
+        CHECK( true == chunk.isInside( 4.0 ) );
+
+        CHECK( false == chunk.isContained( 1.0 ) );
+        CHECK( true == chunk.isContained( 2.5 ) );
+        CHECK( false == chunk.isContained( 4.0 ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( 1., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
       } // THEN
 
       THEN( "an InterpolationTable can be linearised" ) {

--- a/src/scion/math/IntervalDomain.hpp
+++ b/src/scion/math/IntervalDomain.hpp
@@ -80,6 +80,27 @@ namespace math {
       }
       return false;
     }
+
+    /**
+     *  @brief Comparison operator: equal
+     *
+     *  @param[in] right   the domain on the right hand side
+     */
+    bool operator==( const IntervalDomain& right ) const noexcept {
+
+      return ( ( this->lowerLimit() == right.lowerLimit() ) &&
+               ( this->upperLimit() == right.upperLimit() ) );
+    }
+
+    /**
+     *  @brief Comparison operator: not equal
+     *
+     *  @param[in] right   the domain on the right hand side
+     */
+    bool operator!=( const IntervalDomain& right ) const noexcept {
+
+      return ! this->operator==( right );
+    }
   };
 
 } // math namespace

--- a/src/scion/math/IntervalDomain/src/ctor.hpp
+++ b/src/scion/math/IntervalDomain/src/ctor.hpp
@@ -1,4 +1,9 @@
 /**
+ *  @brief Default constructor (for pybind11 purposes only)
+ */
+IntervalDomain() = default;
+
+/**
  *  @brief Constructor
  *
  *  @param lower   the lower limit of the domain

--- a/src/scion/math/IntervalDomain/test/IntervalDomain.test.cpp
+++ b/src/scion/math/IntervalDomain/test/IntervalDomain.test.cpp
@@ -36,13 +36,24 @@ SCENARIO( "IntervalDomain" ) {
         CHECK( true == chunk.isInside(  1.0 ) );
         CHECK( false == chunk.isInside( max ) );
 
-        CHECK( false == chunk.isInside( min ) );
+        CHECK( false == chunk.isContained( min ) );
         CHECK( false == chunk.isContained( -1.0 ) );
         CHECK( true == chunk.isContained( -0.5 ) );
         CHECK( true == chunk.isContained(  0.0 ) );
         CHECK( true == chunk.isContained(  0.5 ) );
         CHECK( false == chunk.isContained(  1.0 ) );
-        CHECK( false == chunk.isInside( max ) );
+        CHECK( false == chunk.isContained( max ) );
+      } // THEN
+
+      THEN( "an IntervalDomain can be compared" ) {
+
+        IntervalDomain< double > same( -1., 1. );
+        IntervalDomain< double > different( 0., 1. );
+
+        CHECK( true == ( chunk == same ) );
+        CHECK( false == ( chunk == different ) );
+        CHECK( false == ( chunk != same ) );
+        CHECK( true == ( chunk != different ) );
       } // THEN
     } // WHEN
   } // GIVEN

--- a/src/scion/math/LegendreSeries.hpp
+++ b/src/scion/math/LegendreSeries.hpp
@@ -91,6 +91,7 @@ namespace math {
     using Parent::operator();
     using Parent::isInside;
     using Parent::isContained;
+    using Parent::isSameDomain;
   };
 
 } // math namespace

--- a/src/scion/math/LegendreSeries/test/LegendreSeries.test.cpp
+++ b/src/scion/math/LegendreSeries/test/LegendreSeries.test.cpp
@@ -9,6 +9,7 @@
 using namespace njoy::scion;
 template < typename X, typename Y = X > using LegendreSeries = math::LegendreSeries< X, Y >;
 template < typename X > using IntervalDomain = math::IntervalDomain< X >;
+template < typename X > using OpenDomain = math::OpenDomain< X >;
 template < typename X, typename Y = X >
 using InterpolationTable = math::InterpolationTable< X, Y >;
 template < typename X > using IntervalDomain = math::IntervalDomain< X >;
@@ -113,6 +114,21 @@ SCENARIO( "LegendreSeries" ) {
 
         CHECK( 1 == roots.size() );
         CHECK(  0.0 == Approx( roots[0] ) );
+      } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( -1. ) );
+        CHECK( true == chunk.isInside(  0. ) );
+        CHECK( true == chunk.isInside(  1. ) );
+
+        CHECK( false == chunk.isContained( -1. ) );
+        CHECK( true == chunk.isContained( 0. ) );
+        CHECK( false == chunk.isContained( 1. ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( -1., 1. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 1. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
       } // THEN
 
       THEN( "a PolynomialSeries can be linearised" ) {

--- a/src/scion/math/LinearLinearTable.hpp
+++ b/src/scion/math/LinearLinearTable.hpp
@@ -107,6 +107,7 @@ namespace math {
     using Parent::operator();
     using Parent::isInside;
     using Parent::isContained;
+    using Parent::isSameDomain;
   };
 
 } // math namespace

--- a/src/scion/math/LinearLinearTable/test/LinearLinearTable.test.cpp
+++ b/src/scion/math/LinearLinearTable/test/LinearLinearTable.test.cpp
@@ -13,6 +13,7 @@ template < typename X, typename Y = X,
            typename YContainer = std::vector< Y > >
 using LinearLinearTable = math::LinearLinearTable< X, Y, XContainer, YContainer >;
 template < typename X > using IntervalDomain = math::IntervalDomain< X >;
+template < typename X > using OpenDomain = math::OpenDomain< X >;
 using InterpolationType = interpolation::InterpolationType;
 
 SCENARIO( "LinearLinearTable" ) {
@@ -67,6 +68,21 @@ SCENARIO( "LinearLinearTable" ) {
         CHECK( linear.first == chunk.x() );
         CHECK( linear.second == chunk.y() );
       } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( 1.0 ) );
+        CHECK( true == chunk.isInside( 2.5 ) );
+        CHECK( true == chunk.isInside( 4.0 ) );
+
+        CHECK( false == chunk.isContained( 1.0 ) );
+        CHECK( true == chunk.isContained( 2.5 ) );
+        CHECK( false == chunk.isContained( 4.0 ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( 1., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
+      } // THEN
     } // WHEN
 
     WHEN( "the data is given explicitly using iterator views" ) {
@@ -120,6 +136,21 @@ SCENARIO( "LinearLinearTable" ) {
         auto linear = chunk.linearise();
         CHECK( linear.first == chunk.x() );
         CHECK( linear.second == chunk.y() );
+      } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( 1.0 ) );
+        CHECK( true == chunk.isInside( 2.5 ) );
+        CHECK( true == chunk.isInside( 4.0 ) );
+
+        CHECK( false == chunk.isContained( 1.0 ) );
+        CHECK( true == chunk.isContained( 2.5 ) );
+        CHECK( false == chunk.isContained( 4.0 ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( 1., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
       } // THEN
     } // WHEN
   } // GIVEN

--- a/src/scion/math/LinearLogTable.hpp
+++ b/src/scion/math/LinearLogTable.hpp
@@ -98,6 +98,7 @@ namespace math {
     using Parent::operator();
     using Parent::isInside;
     using Parent::isContained;
+    using Parent::isSameDomain;
   };
 
 } // math namespace

--- a/src/scion/math/LinearLogTable/src/ctor.hpp
+++ b/src/scion/math/LinearLogTable/src/ctor.hpp
@@ -7,9 +7,8 @@ LinearLogTable( Table&& table ) :
   Parent( IntervalDomain( table.x().front(), table.x().back() ) ),
   table_( std::move( table ) ) {
 
-  verifyTable( this->table_.x(), this->table_.y() );    
+  verifyTable( this->table_.x(), this->table_.y() );
 }
-
 
 public:
 

--- a/src/scion/math/LinearLogTable/test/LinearLogTable.test.cpp
+++ b/src/scion/math/LinearLogTable/test/LinearLogTable.test.cpp
@@ -13,6 +13,7 @@ template < typename X, typename Y = X,
            typename YContainer = std::vector< Y > >
 using LinearLogTable = math::LinearLogTable< X, Y, XContainer, YContainer >;
 template < typename X > using IntervalDomain = math::IntervalDomain< X >;
+template < typename X > using OpenDomain = math::OpenDomain< X >;
 using InterpolationType = interpolation::InterpolationType;
 
 SCENARIO( "LinearLogTable" ) {
@@ -120,6 +121,21 @@ SCENARIO( "LinearLogTable" ) {
         CHECK( 1.110360364 == Approx( linear.second[23] ) );
         CHECK( 1.          == Approx( linear.second[24] ) );
       } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( 1.0 ) );
+        CHECK( true == chunk.isInside( 2.5 ) );
+        CHECK( true == chunk.isInside( 4.0 ) );
+
+        CHECK( false == chunk.isContained( 1.0 ) );
+        CHECK( true == chunk.isContained( 2.5 ) );
+        CHECK( false == chunk.isContained( 4.0 ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( 1., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
+      } // THEN
     } // WHEN
 
     WHEN( "the data is given explicitly using iterator views" ) {
@@ -226,6 +242,21 @@ SCENARIO( "LinearLogTable" ) {
         CHECK( 1.224339739 == Approx( linear.second[22] ) );
         CHECK( 1.110360364 == Approx( linear.second[23] ) );
         CHECK( 1.          == Approx( linear.second[24] ) );
+      } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( 1.0 ) );
+        CHECK( true == chunk.isInside( 2.5 ) );
+        CHECK( true == chunk.isInside( 4.0 ) );
+
+        CHECK( false == chunk.isContained( 1.0 ) );
+        CHECK( true == chunk.isContained( 2.5 ) );
+        CHECK( false == chunk.isContained( 4.0 ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( 1., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
       } // THEN
     } // WHEN
   } // GIVEN

--- a/src/scion/math/LogLinearTable.hpp
+++ b/src/scion/math/LogLinearTable.hpp
@@ -98,6 +98,7 @@ namespace math {
     using Parent::operator();
     using Parent::isInside;
     using Parent::isContained;
+    using Parent::isSameDomain;
   };
 
 } // math namespace

--- a/src/scion/math/LogLinearTable/test/LogLinearTable.test.cpp
+++ b/src/scion/math/LogLinearTable/test/LogLinearTable.test.cpp
@@ -13,6 +13,7 @@ template < typename X, typename Y = X,
            typename YContainer = std::vector< Y > >
 using LogLinearTable = math::LogLinearTable< X, Y, XContainer, YContainer >;
 template < typename X > using IntervalDomain = math::IntervalDomain< X >;
+template < typename X > using OpenDomain = math::OpenDomain< X >;
 using InterpolationType = interpolation::InterpolationType;
 
 SCENARIO( "LogLinearTable" ) {
@@ -112,6 +113,21 @@ SCENARIO( "LogLinearTable" ) {
         CHECK( 1.090507733 == Approx( linear.second[19] ) );
         CHECK( 1.          == Approx( linear.second[20] ) );
       } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( 1.0 ) );
+        CHECK( true == chunk.isInside( 2.5 ) );
+        CHECK( true == chunk.isInside( 4.0 ) );
+
+        CHECK( false == chunk.isContained( 1.0 ) );
+        CHECK( true == chunk.isContained( 2.5 ) );
+        CHECK( false == chunk.isContained( 4.0 ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( 1., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
+      } // THEN
     } // WHEN
 
     WHEN( "the data is given explicitly using iterator views" ) {
@@ -210,6 +226,21 @@ SCENARIO( "LogLinearTable" ) {
         CHECK( 1.189207115 == Approx( linear.second[18] ) );
         CHECK( 1.090507733 == Approx( linear.second[19] ) );
         CHECK( 1.          == Approx( linear.second[20] ) );
+      } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( 1.0 ) );
+        CHECK( true == chunk.isInside( 2.5 ) );
+        CHECK( true == chunk.isInside( 4.0 ) );
+
+        CHECK( false == chunk.isContained( 1.0 ) );
+        CHECK( true == chunk.isContained( 2.5 ) );
+        CHECK( false == chunk.isContained( 4.0 ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( 1., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
       } // THEN
     } // WHEN
   } // GIVEN

--- a/src/scion/math/LogLogTable.hpp
+++ b/src/scion/math/LogLogTable.hpp
@@ -98,6 +98,7 @@ namespace math {
     using Parent::operator();
     using Parent::isInside;
     using Parent::isContained;
+    using Parent::isSameDomain;
   };
 
 } // math namespace

--- a/src/scion/math/LogLogTable/test/LogLogTable.test.cpp
+++ b/src/scion/math/LogLogTable/test/LogLogTable.test.cpp
@@ -13,6 +13,7 @@ template < typename X, typename Y = X,
            typename YContainer = std::vector< Y > >
 using LogLogTable = math::LogLogTable< X, Y, XContainer, YContainer >;
 template < typename X > using IntervalDomain = math::IntervalDomain< X >;
+template < typename X > using OpenDomain = math::OpenDomain< X >;
 using InterpolationType = interpolation::InterpolationType;
 
 SCENARIO( "LogLogTable" ) {
@@ -138,6 +139,21 @@ SCENARIO( "LogLogTable" ) {
         CHECK( 1.038673501 == Approx( linear.second[32] ) );
         CHECK( 1.          == Approx( linear.second[33] ) );
       } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( 1.0 ) );
+        CHECK( true == chunk.isInside( 2.5 ) );
+        CHECK( true == chunk.isInside( 4.0 ) );
+
+        CHECK( false == chunk.isContained( 1.0 ) );
+        CHECK( true == chunk.isContained( 2.5 ) );
+        CHECK( false == chunk.isContained( 4.0 ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( 1., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
+      } // THEN
     } // WHEN
 
     WHEN( "the data is given explicitly using iterator views" ) {
@@ -262,6 +278,21 @@ SCENARIO( "LogLogTable" ) {
         CHECK( 1.079497846 == Approx( linear.second[31] ) );
         CHECK( 1.038673501 == Approx( linear.second[32] ) );
         CHECK( 1.          == Approx( linear.second[33] ) );
+      } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( 1.0 ) );
+        CHECK( true == chunk.isInside( 2.5 ) );
+        CHECK( true == chunk.isInside( 4.0 ) );
+
+        CHECK( false == chunk.isContained( 1.0 ) );
+        CHECK( true == chunk.isContained( 2.5 ) );
+        CHECK( false == chunk.isContained( 4.0 ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( 1., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
       } // THEN
     } // WHEN
   } // GIVEN

--- a/src/scion/math/OpenDomain.hpp
+++ b/src/scion/math/OpenDomain.hpp
@@ -52,6 +52,26 @@ namespace math {
 
       return true;
     }
+
+    /**
+     *  @brief Comparison operator: equal
+     *
+     *  @param[in] right   the domain on the right hand side
+     */
+    bool operator==( const OpenDomain& right ) const noexcept {
+
+      return true;
+    }
+
+    /**
+     *  @brief Comparison operator: not equal
+     *
+     *  @param[in] right   the domain on the right hand side
+     */
+    bool operator!=( const OpenDomain& right ) const noexcept {
+
+      return false;
+    }
   };
 
 } // math namespace

--- a/src/scion/math/OpenDomain/test/OpenDomain.test.cpp
+++ b/src/scion/math/OpenDomain/test/OpenDomain.test.cpp
@@ -38,6 +38,15 @@ SCENARIO( "OpenDomain" ) {
         CHECK( true == chunk.isContained(  1.0 ) );
         CHECK( true == chunk.isInside( max ) );
       } // THEN
+
+
+      THEN( "an IntervalDomain can be compared" ) {
+
+        OpenDomain< double > same;
+
+        CHECK( true == ( chunk == same ) );
+        CHECK( false == ( chunk != same ) );
+      } // THEN
     } // WHEN
   } // GIVEN
 } // SCENARIO

--- a/src/scion/math/PolynomialSeries.hpp
+++ b/src/scion/math/PolynomialSeries.hpp
@@ -80,6 +80,7 @@ namespace math {
     using Parent::operator();
     using Parent::isInside;
     using Parent::isContained;
+    using Parent::isSameDomain;
   };
 
 } // math namespace

--- a/src/scion/math/PolynomialSeries/test/PolynomialSeries.test.cpp
+++ b/src/scion/math/PolynomialSeries/test/PolynomialSeries.test.cpp
@@ -9,6 +9,7 @@
 using namespace njoy::scion;
 template < typename X, typename Y = X > using PolynomialSeries = math::PolynomialSeries< X, Y >;
 template < typename X > using IntervalDomain = math::IntervalDomain< X >;
+template < typename X > using OpenDomain = math::OpenDomain< X >;
 template < typename X, typename Y = X >
 using InterpolationTable = math::InterpolationTable< X, Y >;
 template < typename X > using IntervalDomain = math::IntervalDomain< X >;
@@ -131,6 +132,21 @@ SCENARIO( "PolynomialSeries" ) {
 
         CHECK( 1 == roots.size() );
         CHECK(  0.0 == Approx( roots[0] ) );
+      } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( -1.0 ) );
+        CHECK( true == chunk.isInside(  0.0 ) );
+        CHECK( true == chunk.isInside(  1.0 ) );
+
+        CHECK( false == chunk.isContained( -1.0 ) );
+        CHECK( true == chunk.isContained(  0.0 ) );
+        CHECK( false == chunk.isContained(  1.0 ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( -1., +1. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( -1., 0. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
       } // THEN
 
       THEN( "a PolynomialSeries can be linearised" ) {

--- a/src/scion/math/SeriesBase.hpp
+++ b/src/scion/math/SeriesBase.hpp
@@ -243,6 +243,7 @@ namespace math {
     using Parent::operator();
     using Parent::isInside;
     using Parent::isContained;
+    using Parent::isSameDomain;
   };
 
 } // math namespace


### PR DESCRIPTION
This adds comparison (== and !=) to all domain types (currently only OpenDomain and IntervalDomain), which is in turn used to implement a isSameDomain(...) function on FunctionBase and its derived types. This function is useful to allow a user to verify that the domain is the same between two functional objects of the same type prior to doing an operation such as +, -, etc.