### PR TITLE
Feature/more interpolationtable

### DIFF
--- a/python/test/math/Test_scion_math_InterpolationTable.py
+++ b/python/test/math/Test_scion_math_InterpolationTable.py
@@ -1069,8 +1069,8 @@ class Test_scion_math_InterpolationTable( unittest.TestCase ) :
         # the x grid has a jump at the end
         with self.assertRaises( Exception ) :
 
-            chunk = InterpolationTable( x = [ 1., 2., 2., 4., 4. ],
-                                        y = [ 4., 3., 3., 1., 4. ] )
+            chunk = InterpolationTable( x = [ 1., 2., 4., 4. ],
+                                        y = [ 4., 3., 1., 4. ] )
 
 if __name__ == '__main__' :
 

--- a/python/test/math/Test_scion_math_InterpolationTable.py
+++ b/python/test/math/Test_scion_math_InterpolationTable.py
@@ -15,7 +15,7 @@ class Test_scion_math_InterpolationTable( unittest.TestCase ) :
 
     def test_component( self ) :
 
-        def verify_chunk( self, chunk ) :
+        def verify_chunk1( self, chunk ) :
 
             # verify content
             self.assertEqual( 4, chunk.number_points )
@@ -233,7 +233,247 @@ class Test_scion_math_InterpolationTable( unittest.TestCase ) :
             self.assertEqual( 3, result.boundaries[0] )
             self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
 
-        def verify_chunk_no_jump( self, chunk ) :
+        def verify_chunk2( self, chunk ) :
+
+            # verify content
+            self.assertEqual( 5, len( chunk.x ) )
+            self.assertEqual( 5, len( chunk.y ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.x[0] )
+            self.assertAlmostEqual( 2., chunk.x[1] )
+            self.assertAlmostEqual( 2., chunk.x[2] )
+            self.assertAlmostEqual( 3., chunk.x[3] )
+            self.assertAlmostEqual( 4., chunk.x[4] )
+            self.assertAlmostEqual( 4., chunk.y[0] )
+            self.assertAlmostEqual( 3., chunk.y[1] )
+            self.assertAlmostEqual( 4., chunk.y[2] )
+            self.assertAlmostEqual( 3., chunk.y[3] )
+            self.assertAlmostEqual( 2., chunk.y[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+
+            # verify evaluation - values of x in the x grid
+            self.assertAlmostEqual( 4., chunk( x = 1. ) )
+            self.assertAlmostEqual( 4., chunk( x = 2. ) )
+            self.assertAlmostEqual( 3., chunk( x = 3. ) )
+            self.assertAlmostEqual( 2., chunk( x = 4. ) )
+
+            # verify evaluation - values of x outside the x grid
+            self.assertAlmostEqual( 0.0, chunk( x = 0. ) )
+            self.assertAlmostEqual( 0.0, chunk( x = 5. ) )
+
+            # verify evaluation - values of x inside the x grid
+            self.assertAlmostEqual( 3.5, chunk( x = 1.5 ) )
+            self.assertAlmostEqual( 3.5, chunk( x = 2.5 ) )
+            self.assertAlmostEqual( 2.5, chunk( x = 3.5 ) )
+
+            # verify domain comparison
+            self.assertEqual( True, chunk.is_inside( 1. ) )
+            self.assertEqual( True, chunk.is_inside( 2.5 ) )
+            self.assertEqual( True, chunk.is_inside( 4. ) )
+
+            self.assertEqual( False, chunk.is_contained( 1. ) )
+            self.assertEqual( True, chunk.is_contained( 2.5 ) )
+            self.assertEqual( False, chunk.is_contained( 4. ) )
+
+            self.assertEqual( True, chunk.is_same_domain( IntervalDomain( 1., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( IntervalDomain( 0., 4. ) ) )
+            self.assertEqual( False, chunk.is_same_domain( OpenDomain() ) )
+
+            # verify linearisation
+            linear = chunk.linearise()
+
+            self.assertEqual( 5, linear.number_points )
+            self.assertEqual( 2, linear.number_regions )
+
+            self.assertEqual( 5, len( linear.x ) )
+            self.assertEqual( 5, len( linear.y ) )
+            self.assertEqual( 2, len( linear.boundaries ) )
+            self.assertEqual( 2, len( linear.interpolants ) )
+
+            self.assertEqual( 1, linear.boundaries[0] )
+            self.assertEqual( 4, linear.boundaries[1] )
+
+            self.assertEqual( InterpolationType.LinearLinear, linear.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, linear.interpolants[1] )
+
+            self.assertAlmostEqual( 1., linear.x[0] )
+            self.assertAlmostEqual( 2., linear.x[1] )
+            self.assertAlmostEqual( 2., linear.x[2] )
+            self.assertAlmostEqual( 3., linear.x[3] )
+            self.assertAlmostEqual( 4., linear.x[4] )
+
+            self.assertAlmostEqual( 4., linear.y[0] )
+            self.assertAlmostEqual( 3., linear.y[1] )
+            self.assertAlmostEqual( 4., linear.y[2] )
+            self.assertAlmostEqual( 3., linear.y[3] )
+            self.assertAlmostEqual( 2., linear.y[4] )
+
+            # verify arithmetic operators
+            chunk += 2.
+            self.assertEqual( 5, len( chunk.x ) )
+            self.assertEqual( 5, len( chunk.y ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.x[0] )
+            self.assertAlmostEqual( 2., chunk.x[1] )
+            self.assertAlmostEqual( 2., chunk.x[2] )
+            self.assertAlmostEqual( 3., chunk.x[3] )
+            self.assertAlmostEqual( 4., chunk.x[4] )
+            self.assertAlmostEqual( 6., chunk.y[0] )
+            self.assertAlmostEqual( 5., chunk.y[1] )
+            self.assertAlmostEqual( 6., chunk.y[2] )
+            self.assertAlmostEqual( 5., chunk.y[3] )
+            self.assertAlmostEqual( 4., chunk.y[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+
+            chunk -= 2.
+            self.assertEqual( 5, len( chunk.x ) )
+            self.assertEqual( 5, len( chunk.y ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.x[0] )
+            self.assertAlmostEqual( 2., chunk.x[1] )
+            self.assertAlmostEqual( 2., chunk.x[2] )
+            self.assertAlmostEqual( 3., chunk.x[3] )
+            self.assertAlmostEqual( 4., chunk.x[4] )
+            self.assertAlmostEqual( 4., chunk.y[0] )
+            self.assertAlmostEqual( 3., chunk.y[1] )
+            self.assertAlmostEqual( 4., chunk.y[2] )
+            self.assertAlmostEqual( 3., chunk.y[3] )
+            self.assertAlmostEqual( 2., chunk.y[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+
+            chunk *= 2.
+            self.assertEqual( 5, len( chunk.x ) )
+            self.assertEqual( 5, len( chunk.y ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.x[0] )
+            self.assertAlmostEqual( 2., chunk.x[1] )
+            self.assertAlmostEqual( 2., chunk.x[2] )
+            self.assertAlmostEqual( 3., chunk.x[3] )
+            self.assertAlmostEqual( 4., chunk.x[4] )
+            self.assertAlmostEqual( 8., chunk.y[0] )
+            self.assertAlmostEqual( 6., chunk.y[1] )
+            self.assertAlmostEqual( 8., chunk.y[2] )
+            self.assertAlmostEqual( 6., chunk.y[3] )
+            self.assertAlmostEqual( 4., chunk.y[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+
+            chunk /= 2.
+            self.assertEqual( 5, len( chunk.x ) )
+            self.assertEqual( 5, len( chunk.y ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.x[0] )
+            self.assertAlmostEqual( 2., chunk.x[1] )
+            self.assertAlmostEqual( 2., chunk.x[2] )
+            self.assertAlmostEqual( 3., chunk.x[3] )
+            self.assertAlmostEqual( 4., chunk.x[4] )
+            self.assertAlmostEqual( 4., chunk.y[0] )
+            self.assertAlmostEqual( 3., chunk.y[1] )
+            self.assertAlmostEqual( 4., chunk.y[2] )
+            self.assertAlmostEqual( 3., chunk.y[3] )
+            self.assertAlmostEqual( 2., chunk.y[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+
+            result = chunk + 2.
+            self.assertEqual( 5, len( result.x ) )
+            self.assertEqual( 5, len( result.y ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.x[0] )
+            self.assertAlmostEqual( 2., result.x[1] )
+            self.assertAlmostEqual( 2., result.x[2] )
+            self.assertAlmostEqual( 3., result.x[3] )
+            self.assertAlmostEqual( 4., result.x[4] )
+            self.assertAlmostEqual( 6., result.y[0] )
+            self.assertAlmostEqual( 5., result.y[1] )
+            self.assertAlmostEqual( 6., result.y[2] )
+            self.assertAlmostEqual( 5., result.y[3] )
+            self.assertAlmostEqual( 4., result.y[4] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+
+            result = chunk - 2.
+            self.assertEqual( 5, len( result.x ) )
+            self.assertEqual( 5, len( result.y ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.x[0] )
+            self.assertAlmostEqual( 2., result.x[1] )
+            self.assertAlmostEqual( 2., result.x[2] )
+            self.assertAlmostEqual( 3., result.x[3] )
+            self.assertAlmostEqual( 4., result.x[4] )
+            self.assertAlmostEqual( 2., result.y[0] )
+            self.assertAlmostEqual( 1., result.y[1] )
+            self.assertAlmostEqual( 2., result.y[2] )
+            self.assertAlmostEqual( 1., result.y[3] )
+            self.assertAlmostEqual( 0., result.y[4] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+
+            result = chunk * 2.
+            self.assertEqual( 5, len( result.x ) )
+            self.assertEqual( 5, len( result.y ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.x[0] )
+            self.assertAlmostEqual( 2., result.x[1] )
+            self.assertAlmostEqual( 2., result.x[2] )
+            self.assertAlmostEqual( 3., result.x[3] )
+            self.assertAlmostEqual( 4., result.x[4] )
+            self.assertAlmostEqual( 8., result.y[0] )
+            self.assertAlmostEqual( 6., result.y[1] )
+            self.assertAlmostEqual( 8., result.y[2] )
+            self.assertAlmostEqual( 6., result.y[3] )
+            self.assertAlmostEqual( 4., result.y[4] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+
+            result = chunk / 2.
+            self.assertEqual( 5, len( result.x ) )
+            self.assertEqual( 5, len( result.y ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual( 1. , result.x[0] )
+            self.assertAlmostEqual( 2. , result.x[1] )
+            self.assertAlmostEqual( 2. , result.x[2] )
+            self.assertAlmostEqual( 3. , result.x[3] )
+            self.assertAlmostEqual( 4. , result.x[4] )
+            self.assertAlmostEqual( 2. , result.y[0] )
+            self.assertAlmostEqual( 1.5, result.y[1] )
+            self.assertAlmostEqual( 2. , result.y[2] )
+            self.assertAlmostEqual( 1.5, result.y[3] )
+            self.assertAlmostEqual( 1. , result.y[4] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+
+        def verify_chunk3( self, chunk ) :
 
             # verify content
             self.assertEqual( 4, chunk.number_points )
@@ -499,7 +739,7 @@ class Test_scion_math_InterpolationTable( unittest.TestCase ) :
             self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
             self.assertEqual( InterpolationType.LinearLog, result.interpolants[1] )
 
-        def verify_chunk_jump( self, chunk ) :
+        def verify_chunk4( self, chunk ) :
 
             # verify content
             self.assertEqual( 5, len( chunk.x ) )
@@ -760,7 +1000,14 @@ class Test_scion_math_InterpolationTable( unittest.TestCase ) :
                                     y = [ 4., 3., 2., 1. ],
                                     interpolant = InterpolationType.LinearLinear )
 
-        verify_chunk( self, chunk )
+        verify_chunk1( self, chunk )
+
+        # the data is given explicitly for data without boundaries and a jump
+        chunk = InterpolationTable( x = [ 1., 2., 2., 3., 4. ],
+                                    y = [ 4., 3., 4., 3., 2. ],
+                                    interpolant = InterpolationType.LinearLinear )
+
+        verify_chunk2( self, chunk )
 
         # the data is given explicitly for data without a jump
         chunk = InterpolationTable( x = [ 1., 2., 3., 4. ],
@@ -769,7 +1016,7 @@ class Test_scion_math_InterpolationTable( unittest.TestCase ) :
                                     interpolants = [ InterpolationType.LinearLinear,
                                                      InterpolationType.LinearLog ] )
 
-        verify_chunk_no_jump( self, chunk )
+        verify_chunk3( self, chunk )
 
         # the data is given explicitly for data with a jump
         chunk = InterpolationTable( x = [ 1., 2., 2., 3., 4. ],
@@ -778,7 +1025,7 @@ class Test_scion_math_InterpolationTable( unittest.TestCase ) :
                                     interpolants = [ InterpolationType.LinearLinear,
                                                      InterpolationType.LinearLog ] )
 
-        verify_chunk_jump( self, chunk )
+        verify_chunk4( self, chunk )
 
     def test_failures( self ) :
 
@@ -799,11 +1046,25 @@ class Test_scion_math_InterpolationTable( unittest.TestCase ) :
             chunk = InterpolationTable( x = [ 1., 2., 3., 4. ],
                                         y = [ 4., 3., 2. ] )
 
+        # the boundaries and interpolants do not have the same size
+        with self.assertRaises( Exception ) :
+
+            chunk = InterpolationTable( x = [ 1., 2., 3., 4. ],
+                                        y = [ 4., 3., 2., 1. ],
+                                        boundaries = [ 3 ],
+                                        interpolants = [] )
+
         # the x grid is not sorted
         with self.assertRaises( Exception ) :
 
             chunk = InterpolationTable( x = [ 1., 3., 2., 4. ],
                                         y = [ 4., 3., 2., 1. ] )
+
+        # the x grid contains a triple x value
+        with self.assertRaises( Exception ) :
+
+            chunk = InterpolationTable( x = [ 1., 2., 2., 2., 3., 4. ],
+                                        y = [ 4., 3., 3., 3., 2., 1. ] )
 
 if __name__ == '__main__' :
 

--- a/python/test/math/Test_scion_math_InterpolationTable.py
+++ b/python/test/math/Test_scion_math_InterpolationTable.py
@@ -1066,6 +1066,12 @@ class Test_scion_math_InterpolationTable( unittest.TestCase ) :
             chunk = InterpolationTable( x = [ 1., 2., 2., 2., 3., 4. ],
                                         y = [ 4., 3., 3., 3., 2., 1. ] )
 
+        # the x grid has a jump at the end
+        with self.assertRaises( Exception ) :
+
+            chunk = InterpolationTable( x = [ 1., 2., 2., 4., 4. ],
+                                        y = [ 4., 3., 3., 1., 4. ] )
+
 if __name__ == '__main__' :
 
     unittest.main()

--- a/src/scion/math/InterpolationTable.hpp
+++ b/src/scion/math/InterpolationTable.hpp
@@ -50,6 +50,7 @@ namespace math {
 
     /* auxiliary function */
     #include "scion/math/InterpolationTable/src/generateTables.hpp"
+    #include "scion/math/InterpolationTable/src/processBoundaries.hpp"
 
     /**
      *  @brief Return the interpolation tables

--- a/src/scion/math/InterpolationTable/src/generateTables.hpp
+++ b/src/scion/math/InterpolationTable/src/generateTables.hpp
@@ -2,40 +2,6 @@ void generateTables() {
 
   std::vector< TableVariant > tables;
 
-  if ( ( ! verification::isAtLeastOfSize( this->x(), 2 ) ) ||
-       ( ! verification::isAtLeastOfSize( this->y(), 2 ) ) ) {
-
-    Log::error( "Insufficient x or y values defined for tabulated data "
-                "(at least 2 points are required)" );
-    Log::info( "x.size(): {}", this->x().size() );
-    Log::info( "y.size(): {}", this->y().size() );
-    throw std::exception();
-  }
-
-  if ( ! verification::isSameSize( this->x(), this->y() ) ) {
-
-    Log::error( "Inconsistent number of x and y values for tabulated data" );
-    Log::info( "x.size(): {}", this->x().size() );
-    Log::info( "y.size(): {}", this->y().size() );
-    throw std::exception();
-  }
-
-  if ( ! verification::isSameSize( this->boundaries(), this->interpolants() ) ) {
-
-    Log::error( "Inconsistent number of boundaries and interpolants for tabulated data" );
-    Log::info( "boundaries.size(): {}", this->boundaries().size() );
-    Log::info( "interpolants.size(): {}", this->interpolants().size() );
-    throw std::exception();
-  }
-
-  if ( this->boundaries().back() != this->numberPoints() - 1 ) {
-
-    Log::error( "The last boundary value does not point to the last x value" );
-    Log::info( "x.size(): {}", this->x().size() );
-    Log::info( "boundaries.back(): {}", this->boundaries().back() );
-    throw std::exception();
-  }
-
   auto xStart = this->x().begin();
   auto yStart = this->y().begin();
   auto xEnd = xStart;

--- a/src/scion/math/InterpolationTable/src/processBoundaries.hpp
+++ b/src/scion/math/InterpolationTable/src/processBoundaries.hpp
@@ -1,0 +1,80 @@
+static std::tuple< std::vector< std::size_t >,
+                   std::vector< interpolation::InterpolationType > >
+processBoundaries( const std::vector< X >& x, const std::vector< Y >& y,
+                   std::vector< std::size_t >&& boundaries,
+                   std::vector< interpolation::InterpolationType >&& interpolants  ) {
+
+  if ( ( ! verification::isAtLeastOfSize( x, 2 ) ) ||
+       ( ! verification::isAtLeastOfSize( y, 2 ) ) ) {
+
+    Log::error( "Insufficient x or y values defined for tabulated data "
+                "(at least 2 points are required)" );
+    Log::info( "x.size(): {}", x.size() );
+    Log::info( "y.size(): {}", y.size() );
+    throw std::exception();
+  }
+
+  if ( ! verification::isSameSize( x, y ) ) {
+
+    Log::error( "Inconsistent number of x and y values for tabulated data" );
+    Log::info( "x.size(): {}", x.size() );
+    Log::info( "y.size(): {}", y.size() );
+    throw std::exception();
+  }
+
+  if ( ! verification::isSameSize( boundaries, interpolants ) ) {
+
+    Log::error( "Inconsistent number of boundaries and interpolants for tabulated data" );
+    Log::info( "boundaries.size(): {}", boundaries.size() );
+    Log::info( "interpolants.size(): {}", interpolants.size() );
+    throw std::exception();
+  }
+
+  if ( boundaries.back() != x.size() - 1 ) {
+
+    Log::error( "The last boundary value does not point to the last x value" );
+    Log::info( "x.size(): {}", x.size() );
+    Log::info( "boundaries.back(): {}", boundaries.back() );
+    throw std::exception();
+  }
+
+  if ( ! verification::isSorted( x ) ) {
+
+    Log::error( "The x values do not appear to be in ascending order" );
+    throw std::exception();
+  }
+
+  auto xIter = std::adjacent_find( x.begin(), x.end() );
+  auto bIter = boundaries.begin();
+  while ( xIter != x.end() ) {
+
+    auto index = std::distance( x.begin(), xIter );
+    bIter = std::lower_bound( bIter, boundaries.end(), index );
+    if ( *bIter != index ) {
+
+      auto iIter = std::next( interpolants.begin(),
+                              std::distance( boundaries.begin(), bIter ) );
+      boundaries.insert( bIter, index );
+      interpolants.insert( iIter, *iIter );
+    }
+    ++xIter;
+    if ( std::next( xIter ) == x.end() ) {
+
+      Log::error( "An x value can only be repeated a maximum of two times" );
+      Log::info( "x = {} is present at least three times", *xIter );
+      throw std::exception();
+    }
+    xIter = std::adjacent_find( xIter, x.end() );
+  }
+
+  return { std::move( boundaries ), std::move( interpolants ) };
+}
+
+static std::tuple< std::vector< std::size_t >,
+                   std::vector< interpolation::InterpolationType > >
+processBoundaries( const std::vector< X >& x, const std::vector< Y >& y,
+                   interpolation::InterpolationType interpolant ) {
+
+  return processBoundaries( x, y,
+                            { x.size() > 0 ? x.size() - 1 : 0 }, { interpolant } );
+}

--- a/src/scion/math/InterpolationTable/src/processBoundaries.hpp
+++ b/src/scion/math/InterpolationTable/src/processBoundaries.hpp
@@ -60,6 +60,11 @@ processBoundaries( const std::vector< X >& x, const std::vector< Y >& y,
     ++xIter;
     if ( std::next( xIter ) == x.end() ) {
 
+      Log::error( "A jump in the x grid cannot occur at the end of the x grid" );
+      throw std::exception();
+    }
+    if ( *std::next( xIter ) == *xIter ) {
+
       Log::error( "An x value can only be repeated a maximum of two times" );
       Log::info( "x = {} is present at least three times", *xIter );
       throw std::exception();

--- a/src/scion/math/InterpolationTable/test/InterpolationTable.test.cpp
+++ b/src/scion/math/InterpolationTable/test/InterpolationTable.test.cpp
@@ -1237,5 +1237,16 @@ SCENARIO( "InterpolationTable" ) {
         CHECK_THROWS( InterpolationTable< double >( std::move( x ), std::move( y ) ) );
       } // THEN
     } // WHEN
+
+    WHEN( "the x grid has a jump at the end" ) {
+
+      std::vector< double > x = { 1., 2., 4., 4. };
+      std::vector< double > y = { 4., 3., 1., 4. };
+
+      THEN( "an exception is thrown" ) {
+
+        CHECK_THROWS( InterpolationTable< double >( std::move( x ), std::move( y ) ) );
+      } // THEN
+    } // WHEN
   } // GIVEN
 } // SCENARIO


### PR DESCRIPTION
This update to the InterpolationTable will now ensure that none of the individual interpolation regions have duplicate points - i.e. if there are jumps in the data, they will be at the boundaries of the regions.

Additional errors detected during construction:
- an x value can appear only a maximum of 2 times in the x grid
- a jump cannot occur at the end of the x grid
