### PR TITLE
Feature/utility log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ target_include_directories( scion INTERFACE src/ )
 target_link_libraries( scion
     INTERFACE catch-adapter
     INTERFACE eigen
-    INTERFACE spdlog::spdlog_header_only
+    INTERFACE spdlog::spdlog
     )
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,9 +60,9 @@ include_directories( src/ )
 add_library( scion INTERFACE )
 target_include_directories( scion INTERFACE src/ )
 target_link_libraries( scion
-    INTERFACE Log
     INTERFACE catch-adapter
     INTERFACE eigen
+    INTERFACE spdlog::spdlog_header_only
     )
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/cmake/develop_dependencies.cmake
+++ b/cmake/develop_dependencies.cmake
@@ -12,9 +12,9 @@ FetchContent_Declare( eigen
     )
 set( BUILD_TESTING CACHE BOOL OFF )
 
-FetchContent_Declare( Log
-    GIT_REPOSITORY  https://github.com/njoy/Log
-    GIT_TAG         origin/master
+FetchContent_Declare( spdlog
+    GIT_REPOSITORY  https://github.com/gabime/spdlog
+    GIT_TAG         v1.11.0
     GIT_SHALLOW     TRUE
     )
 
@@ -35,7 +35,7 @@ FetchContent_Declare( pybind11
 
 FetchContent_MakeAvailable(
     eigen
-    Log
+    spdlog
     catch-adapter
     pybind11
     )

--- a/cmake/develop_dependencies.cmake
+++ b/cmake/develop_dependencies.cmake
@@ -17,6 +17,7 @@ FetchContent_Declare( spdlog
     GIT_TAG         v1.11.0
     GIT_SHALLOW     TRUE
     )
+set( SPDLOG_BUILD_PIC CACHE INTERNAL BOOL ON )
 
 FetchContent_Declare( catch-adapter
     GIT_REPOSITORY  https://github.com/njoy/catch-adapter

--- a/cmake/release_dependencies.cmake
+++ b/cmake/release_dependencies.cmake
@@ -25,6 +25,7 @@ FetchContent_Declare( spdlog
     GIT_REPOSITORY  https://github.com/gabime/spdlog
     GIT_TAG         ad0e89cbfb4d0c1ce4d097e134eb7be67baebb36 # tag: v1.11.0
     )
+set( SPDLOG_BUILD_PIC CACHE INTERNAL BOOL ON )
 
 #######################################################################
 # Load dependencies

--- a/cmake/release_dependencies.cmake
+++ b/cmake/release_dependencies.cmake
@@ -16,11 +16,6 @@ FetchContent_Declare( eigen
     )
 set( BUILD_TESTING CACHE BOOL OFF )
 
-FetchContent_Declare( Log
-    GIT_REPOSITORY  https://github.com/njoy/Log
-    GIT_TAG         52962b7796afe37ef1d8f7edb4bf9ecb1b868d15
-    )
-
 FetchContent_Declare( pybind11
     GIT_REPOSITORY  https://github.com/pybind/pybind11
     GIT_TAG         80dc998efced8ceb2be59756668a7e90e8bef917 # tag: v2.10.1
@@ -28,9 +23,8 @@ FetchContent_Declare( pybind11
 
 FetchContent_Declare( spdlog
     GIT_REPOSITORY  https://github.com/gabime/spdlog
-    GIT_TAG         a51b4856377a71f81b6d74b9af459305c4c644f8
+    GIT_TAG         ad0e89cbfb4d0c1ce4d097e134eb7be67baebb36 # tag: v1.11.0
     )
-set( SPDLOG_BUILD_TESTING CACHE BOOL OFF )
 
 #######################################################################
 # Load dependencies
@@ -39,7 +33,6 @@ set( SPDLOG_BUILD_TESTING CACHE BOOL OFF )
 FetchContent_MakeAvailable(
     catch-adapter
     eigen
-    Log
     pybind11
     spdlog
     )

--- a/cmake/unit_testing.cmake
+++ b/cmake/unit_testing.cmake
@@ -11,6 +11,7 @@ enable_testing()
 #######################################################################
 
 add_subdirectory( src/utility/IteratorView/test )
+add_subdirectory( src/utility/Log/test )
 
 add_subdirectory( src/scion/verification/ranges/test )
 

--- a/src/scion/interpolation/Table.hpp
+++ b/src/scion/interpolation/Table.hpp
@@ -6,7 +6,7 @@
 #include <iterator>
 
 // other includes
-#include "Log.hpp"
+#include "utility/Log.hpp"
 #include "scion/verification/ranges.hpp"
 
 namespace njoy {

--- a/src/scion/math/InterpolationTable.hpp
+++ b/src/scion/math/InterpolationTable.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 // other includes
+#include "utility/Log.hpp"
 #include "utility/IteratorView.hpp"
 #include "scion/interpolation/InterpolationType.hpp"
 #include "scion/linearisation/ToleranceConvergence.hpp"

--- a/src/scion/math/IntervalDomain.hpp
+++ b/src/scion/math/IntervalDomain.hpp
@@ -4,7 +4,7 @@
 // system includes
 
 // other includes
-#include "Log.hpp"
+#include "utility/Log.hpp"
 
 namespace njoy {
 namespace scion {

--- a/src/scion/math/SeriesBase.hpp
+++ b/src/scion/math/SeriesBase.hpp
@@ -4,6 +4,7 @@
 // system includes
 
 // other includes
+#include "utility/Log.hpp"
 #include "scion/linearisation/grid.hpp"
 #include "scion/linearisation/ToleranceConvergence.hpp"
 #include "scion/linearisation/MidpointSplit.hpp"

--- a/src/scion/math/SingleTableBase.hpp
+++ b/src/scion/math/SingleTableBase.hpp
@@ -4,6 +4,7 @@
 // system includes
 
 // other includes
+#include "utility/Log.hpp"
 #include "scion/interpolation/InterpolationType.hpp"
 #include "scion/interpolation/Table.hpp"
 #include "scion/linearisation/ToleranceConvergence.hpp"

--- a/src/scion/math/chebyshev.hpp
+++ b/src/scion/math/chebyshev.hpp
@@ -4,7 +4,7 @@
 // system includes
 
 // other includes
-#include "Log.hpp"
+#include "utility/Log.hpp"
 
 namespace njoy {
 namespace scion {

--- a/src/scion/math/legendre.hpp
+++ b/src/scion/math/legendre.hpp
@@ -4,7 +4,7 @@
 // system includes
 
 // other includes
-#include "Log.hpp"
+#include "utility/Log.hpp"
 
 namespace njoy {
 namespace scion {

--- a/src/utility/Log.hpp
+++ b/src/utility/Log.hpp
@@ -1,0 +1,113 @@
+#ifndef NJOY_UTILITY_LOG
+#define NJOY_UTILITY_LOG
+
+// system includes
+
+// other includes
+#include "spdlog/spdlog.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
+
+namespace njoy {
+namespace utility {
+
+/**
+ *  @brief A singleton logger for njoy components
+ */
+class Log {
+
+  static auto initialize_logger() {
+
+    auto instance = spdlog::stdout_color_st( "njoy" );
+    instance->set_pattern( "[%^%l%$] %v" );
+    #ifndef NDEBUG
+    instance->set_level( spdlog::level::debug );
+    #endif
+    return instance;
+  }
+
+  static auto& logger() {
+
+    static auto instance = initialize_logger();
+    return instance;
+  }
+
+  /* constructors */
+  Log() {}; // private to avoid creation of Log instances
+
+public:
+
+  Log( const Log& ) = delete;
+  void operator=( const Log& ) = delete;
+
+  /**
+   *  @brief Print a message at the info level
+   *
+   *  For example:
+   *
+   *  int value = 10;
+   *  utility::Log::info( "Some message with a value {}", value );
+   */
+  template< typename... Args >
+  static void info( Args... args ) {
+
+    logger()->info( std::forward< Args >( args )... );
+  }
+
+  /**
+   *  @brief Print a message at the warning level
+   *
+   *  For example:
+   *
+   *  int value = 10;
+   *  utility::Log::warning( "Some message with a value {}", value );
+   */
+  template< typename... Args >
+  static void warning( Args... args ) {
+
+    logger()->warn( std::forward< Args >( args )... );
+  }
+
+  /**
+   *  @brief Print a message at the error level
+   *
+   *  For example:
+   *
+   *  int value = 10;
+   *  utility::Log::info( "Some message with a value {}", value );
+   */
+  template< typename... Args >
+  static void error( Args... args ) {
+
+    logger()->error( std::forward< Args >( args )... );
+  }
+
+  /**
+   *  @brief Print a message at the debug level
+   *
+   *  This only prints when NDEBUG is defined when compiling this code.
+   *
+   *  For example:
+   *
+   *  int value = 10;
+   *  utility::Log::debug( "Some message with a value {}", value );
+   */
+  #ifdef NDEBUG
+    template< typename... Args >
+    static void debug( Args... ) {}
+  #else
+    template< typename... Args >
+    static void debug( Args... args ) {
+
+      logger()->debug( std::forward< Args >( args )... );
+    }
+  #endif
+};
+
+} // utility namespace
+
+/* type alias - for backwards compatibility reasons */
+using Log = utility::Log;
+
+} // njoy namespace
+
+#endif

--- a/src/utility/Log.hpp
+++ b/src/utility/Log.hpp
@@ -6,6 +6,7 @@
 // other includes
 #include "spdlog/spdlog.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
+#include "spdlog/sinks/basic_file_sink.h"
 
 namespace njoy {
 namespace utility {
@@ -38,6 +39,24 @@ public:
 
   Log( const Log& ) = delete;
   void operator=( const Log& ) = delete;
+
+  /**
+   *  @brief Direct the logger output to the given file
+   */
+  static void add_sink( const std::string& filename ) {
+
+    auto sink_ptr = std::make_shared< spdlog::sinks::basic_file_sink_st >( filename );
+    sink_ptr->set_pattern( "[%^%l%$] %v" );
+    logger()->sinks().push_back( sink_ptr );
+  }
+
+  /**
+   *  @brief Flush the logger
+   */
+  static void flush() {
+
+    logger()->flush();
+  }
 
   /**
    *  @brief Print a message at the info level

--- a/src/utility/Log/test/CMakeLists.txt
+++ b/src/utility/Log/test/CMakeLists.txt
@@ -1,0 +1,18 @@
+
+add_executable( utility.Log.test Log.test.cpp )
+target_compile_options( utility.Log.test PRIVATE ${${PREFIX}_common_flags}
+$<$<BOOL:${strict}>:${${PREFIX}_strict_flags}>$<$<CONFIG:DEBUG>:
+${${PREFIX}_DEBUG_flags}
+$<$<BOOL:${coverage}>:${${PREFIX}_coverage_flags}>>
+$<$<CONFIG:RELEASE>:
+${${PREFIX}_RELEASE_flags}
+$<$<BOOL:${link_time_optimization}>:${${PREFIX}_link_time_optimization_flags}>
+$<$<BOOL:${nonportable_optimization}>:${${PREFIX}_nonportable_optimization_flags}>>
+
+${CXX_appended_flags} ${scion_appended_flags} )
+target_link_libraries( utility.Log.test PUBLIC scion )
+file( GLOB resources "resources/*" )
+foreach( resource ${resources})
+    file( COPY "${resource}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}" )
+endforeach()
+add_test( NAME utility.Log COMMAND utility.Log.test )

--- a/src/utility/Log/test/Log.test.cpp
+++ b/src/utility/Log/test/Log.test.cpp
@@ -1,0 +1,54 @@
+#define CATCH_CONFIG_MAIN
+
+#include "catch.hpp"
+#include "utility/Log.hpp"
+
+// other includes
+#include <filesystem>
+
+// convenience typedefs
+using namespace njoy::utility;
+
+std::string getContent( std::string filename ) {
+
+  std::stringstream ss;
+  std::ifstream fs( filename, std::ifstream::in );
+  ss << fs.rdbuf();
+  return ss.str();
+}
+
+SCENARIO( "Log" ) {
+
+  GIVEN( "a file name" ) {
+
+    std::string filename = "output.txt";
+    std::filesystem::remove( filename ); // ensure the file is not there
+
+    WHEN( "the Log redirects to a file" ) {
+
+      Log::add_sink( filename );
+
+      THEN( "the file contains the log after flushing" ) {
+
+        Log::error( "Some error occurred" );
+        Log::warning( "Some warning was issued" );
+        Log::info( "Some info was printed" );
+        Log::debug( "Some debug info was given" );
+        Log::flush();
+
+        std::string content = getContent( filename );
+
+#ifdef NDEBUG
+        CHECK( "[error] Some error occurred\n"
+               "[warning] Some warning was issued\n"
+               "[info] Some info was printed\n" == content );
+#else
+        CHECK( "[error] Some error occurred\n"
+               "[warning] Some warning was issued\n"
+               "[info] Some info was printed\n"
+               "[debug] Some debug info was given\n"   == content );
+#endif
+      } // THEN
+    } // WHEN
+  } // GIVEN
+} // SCENARIO


### PR DESCRIPTION
This removes the Log library dependency (this is still dependent on spdlog).

The entire utility folder will be moved to its own library as if contains a number of pieces that are useful in other libraries such as ACEtk and ENDFtk:
- the IteratorView
- the overload struct for visiting
- and now the Log object

This links against the static compiled version of spdlog since that compiles faster (it appears that spdlog 1.9.x and higher have added a newer version of the fmt library that performs compile time format checking - which slows down compilation). The time difference between the header only version of spdlog and the static version is not that important for scion but for larger project like ENDFtk and ACEtk, it may be more important.