### PR TITLE
Fixing newton again

### DIFF
--- a/src/scion/math/SeriesBase/src/roots.hpp
+++ b/src/scion/math/SeriesBase/src/roots.hpp
@@ -31,7 +31,7 @@ std::vector< X > roots( const Y& a = Y( 0. ) ) const {
 
       if ( isCloseToZero( value.imag() ) ) {
 
-        roots.emplace_back( derivative( value.real() ) != X( 0. )
+        roots.emplace_back( !isCloseToZero( derivative( value.real() ) )
                             ? newton( value.real(), functor, derivative )
                             : value.real() );
       }

--- a/src/scion/math/newton.hpp
+++ b/src/scion/math/newton.hpp
@@ -35,11 +35,15 @@ X newton( X estimate, Functor&& functor, Derivative&& derivative,
           int iterations = 5 ) noexcept {
 
   X root = estimate - functor( estimate ) / derivative( estimate );
-  while ( ( ! isClose( root, estimate ) ) || ( iterations != 0 ) ) {
+  while ( ! isClose( root, estimate ) ) {
 
     std::swap( estimate, root );
     root = estimate - functor( estimate ) / derivative( estimate );
     --iterations;
+    if ( iterations == 0 ) {
+
+      break;
+    }
   }
   return root;
 }


### PR DESCRIPTION
An issue occurred with U235 while linearising elastic angular distributions at high energy. This was tracked down to an issue in the newton method used to smooth the roots of the Legendre series.