### PR TITLE
Fix/chebyshev approx roots

### DIFF
--- a/src/scion/math/ChebyshevApproximation/src/roots.hpp
+++ b/src/scion/math/ChebyshevApproximation/src/roots.hpp
@@ -8,5 +8,8 @@
  */
 std::vector< X > roots( const Y& a = Y( 0. ) ) const {
 
-  return this->series_.roots( a );
+  auto roots = this->series_.roots( a );
+  std::transform( roots.begin(), roots.end(), roots.begin(),
+                  [this] ( auto&& x ) { return this->invert( x ); } );
+  return roots;
 }


### PR DESCRIPTION
There was an error in the roots() function on the chebyshev approximation: the roots are calculated using the underlying approximation but they were not transformed to the [a,b] domain of the function.