### PR TITLE
Making a correction to InterpolationTable

### DIFF
--- a/src/scion/math/InterpolationTable/src/ctor.hpp
+++ b/src/scion/math/InterpolationTable/src/ctor.hpp
@@ -65,13 +65,14 @@ private:
  *  @param interpolants   the interpolation types of the interpolation regions
  */
 InterpolationTable(
-    std::tuple< std::vector< std::size_t >,
-                std::vector< interpolation::InterpolationType > >&& boundaries,
-    std::vector< X >&& x, std::vector< Y >&& y ) :
-  Parent( IntervalDomain( x.front(), x.back() ) ),
-  x_( std::move( x ) ), y_( std::move( y ) ),
-  boundaries_( std::move( std::get< 0 >( boundaries ) ) ),
-  interpolants_( std::move( std::get< 1 >( boundaries ) ) ) {
+    std::tuple< std::vector< double >,
+                std::vector< double >,
+                std::vector< std::size_t >,
+                std::vector< interpolation::InterpolationType > >&& data ) :
+  Parent( IntervalDomain( std::get< 0 >( data ).front(), std::get< 0 >( data ).back() ) ),
+  x_( std::move( std::get< 0 >( data ) ) ), y_( std::move( std::get< 1 >( data ) ) ),
+  boundaries_( std::move( std::get< 2 >( data ) ) ),
+  interpolants_( std::move( std::get< 3 >( data ) ) ) {
 
   this->generateTables();
 }
@@ -89,10 +90,9 @@ public:
 InterpolationTable( std::vector< X > x, std::vector< Y > y,
                     std::vector< std::size_t > boundaries,
                     std::vector< interpolation::InterpolationType > interpolants ) :
-  InterpolationTable( processBoundaries( x, y,
+  InterpolationTable( processBoundaries( std::move( x ), std::move( y ),
                                          std::move( boundaries ),
-                                         std::move( interpolants ) ),
-                      std::move( x ), std::move( y ) ) {}
+                                         std::move( interpolants ) ) ) {}
 
 /**
  *  @brief Constructor for tabulated data in a single interpolation zone
@@ -104,5 +104,4 @@ InterpolationTable( std::vector< X > x, std::vector< Y > y,
 InterpolationTable( std::vector< X > x, std::vector< Y > y,
                     interpolation::InterpolationType interpolant =
                         interpolation::InterpolationType::LinearLinear ) :
-  InterpolationTable( processBoundaries( x, y, interpolant ),
-                      std::move( x ), std::move( y ) ) {}
+  InterpolationTable( processBoundaries( std::move( x ), std::move( y ), interpolant ) ) {}

--- a/src/scion/math/InterpolationTable/src/processBoundaries.hpp
+++ b/src/scion/math/InterpolationTable/src/processBoundaries.hpp
@@ -20,7 +20,12 @@
  *  In some cases, the boundary values can point to the second point of a jump. While this is not
  *  an error (we will never interpolate on a jump), we need the boundaries to point to the first
  *  point in the jump instead of the second one. When this is encountered, the boundary value is
- *  adjusted.
+ *  adjusted. This change is made silently as it does not constitute an error on the user side.
+ *
+ *  A jump at the end of the x grid is also not allowed. If a jump is detected at the end of the
+ *  x grid, and if the last y value is zero, then the last point is just removed. A warning is
+ *  issued if this happens to be the case. If the last y value is any other value, an error is
+ *  raised.
  */
 static std::tuple< std::vector< double >,
                    std::vector< double >,

--- a/src/scion/math/InterpolationTable/test/InterpolationTable.test.cpp
+++ b/src/scion/math/InterpolationTable/test/InterpolationTable.test.cpp
@@ -1687,6 +1687,163 @@ SCENARIO( "InterpolationTable" ) {
     } // WHEN
   } // GIVEN
 
+  GIVEN( "non-linearised data with multiple regions with a jump and boundaries "
+         "that point to the second x value in the jump" ) {
+
+    // note: at construction time, the boundary value will be set to the first point in
+    //       the jump. As a result, the final data contained in this InterpolationTable is the
+    //       same as the previous test.
+
+    WHEN( "the data is given explicitly" ) {
+
+      const std::vector< double > x = { 1., 2., 2., 3., 4. };
+      const std::vector< double > y = { 4., 3., 4., 3., 2. };
+      const std::vector< std::size_t > boundaries = { 2, 4 };
+      const std::vector< InterpolationType > interpolants = {
+
+        InterpolationType::LinearLinear,
+        InterpolationType::LinearLog
+      };
+
+      InterpolationTable< double > chunk( std::move( x ), std::move( y ),
+                                          std::move( boundaries ),
+                                          std::move( interpolants ) );
+
+      THEN( "a InterpolationTable can be constructed and members can be tested" ) {
+
+        CHECK( 5 == chunk.x().size() );
+        CHECK( 5 == chunk.y().size() );
+        CHECK( 2 == chunk.boundaries().size() );
+        CHECK( 2 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.x()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.x()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.x()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.x()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.x()[4] ) );
+        CHECK_THAT( 4., WithinRel( chunk.y()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.y()[1] ) );
+        CHECK_THAT( 4., WithinRel( chunk.y()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.y()[3] ) );
+        CHECK_THAT( 2., WithinRel( chunk.y()[4] ) );
+        CHECK( 1 == chunk.boundaries()[0] );           // <-- this is changed from 2 to 1
+        CHECK( 4 == chunk.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLog == chunk.interpolants()[1] );
+        CHECK( false == chunk.isLinearised() );
+
+        CHECK( true == std::holds_alternative< IntervalDomain< double > >( chunk.domain() ) );
+      } // THEN
+
+      THEN( "a InterpolationTable can be evaluated" ) {
+
+        // values of x in the x grid
+        CHECK_THAT( 4., WithinRel( chunk( 1. ) ) );
+        CHECK_THAT( 4., WithinRel( chunk( 2. ) ) );
+        CHECK_THAT( 3., WithinRel( chunk( 3. ) ) );
+        CHECK_THAT( 2., WithinRel( chunk( 4. ) ) );
+
+        // values of x outside the x grid
+        CHECK_THAT( 0., WithinRel( chunk( 0. ) ) );
+        CHECK_THAT( 0., WithinRel( chunk( 5. ) ) );
+
+        // values of x inside the x grid (lin-lin piece)
+        CHECK_THAT( 3.5, WithinRel( chunk( 1.5 ) ) );
+
+        // values of x inside the x grid (lin-log piece)
+        CHECK_THAT( 3.44966028678679, WithinRel( chunk( 2.5 ) ) );
+        CHECK_THAT( 2.46416306545103, WithinRel( chunk( 3.5 ) ) );
+      } // THEN
+
+      THEN( "the domain can be tested" ) {
+
+        CHECK( true == chunk.isInside( 1.0 ) );
+        CHECK( true == chunk.isInside( 2.5 ) );
+        CHECK( true == chunk.isInside( 4.0 ) );
+
+        CHECK( false == chunk.isContained( 1.0 ) );
+        CHECK( true == chunk.isContained( 2.5 ) );
+        CHECK( false == chunk.isContained( 4.0 ) );
+
+        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( 1., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 4. ) ) );
+        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
+      } // THEN
+
+      THEN( "an InterpolationTable can be linearised" ) {
+
+        InterpolationTable< double > linear = chunk.linearise();
+
+        CHECK( 12 == linear.numberPoints() );
+        CHECK( 2 == linear.numberRegions() );
+
+        CHECK( 12 == linear.x().size() );
+        CHECK( 12 == linear.y().size() );
+        CHECK( 2 == linear.boundaries().size() );
+        CHECK( 2 == linear.interpolants().size() );
+
+        CHECK(  1 == linear.boundaries()[0] );
+        CHECK( 11 == linear.boundaries()[1] );
+
+        CHECK( InterpolationType::LinearLinear == linear.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == linear.interpolants()[1] );
+
+        CHECK_THAT( 1.   , WithinRel( linear.x()[0] ) );
+        CHECK_THAT( 2.   , WithinRel( linear.x()[1] ) );
+        CHECK_THAT( 2.   , WithinRel( linear.x()[2] ) );
+        CHECK_THAT( 2.125, WithinRel( linear.x()[3] ) );
+        CHECK_THAT( 2.25 , WithinRel( linear.x()[4] ) );
+        CHECK_THAT( 2.5  , WithinRel( linear.x()[5] ) );
+        CHECK_THAT( 2.75 , WithinRel( linear.x()[6] ) );
+        CHECK_THAT( 3.   , WithinRel( linear.x()[7] ) );
+        CHECK_THAT( 3.25 , WithinRel( linear.x()[8] ) );
+        CHECK_THAT( 3.5  , WithinRel( linear.x()[9] ) );
+        CHECK_THAT( 3.75 , WithinRel( linear.x()[10] ) );
+        CHECK_THAT( 4.   , WithinRel( linear.x()[11] ) );
+
+        CHECK_THAT( 4.              , WithinRel( linear.y()[0] ) );
+        CHECK_THAT( 3.              , WithinRel( linear.y()[1] ) );
+        CHECK_THAT( 4.              , WithinRel( linear.y()[2] ) );
+        CHECK_THAT( 3.85048128530886, WithinRel( linear.y()[3] ) );
+        CHECK_THAT( 3.70951129135145, WithinRel( linear.y()[4] ) );
+        CHECK_THAT( 3.44966028678679, WithinRel( linear.y()[5] ) );
+        CHECK_THAT( 3.21459646033567, WithinRel( linear.y()[6] ) );
+        CHECK_THAT( 3.              , WithinRel( linear.y()[7] ) );
+        CHECK_THAT( 2.72176678584324, WithinRel( linear.y()[8] ) );
+        CHECK_THAT( 2.46416306545103, WithinRel( linear.y()[9] ) );
+        CHECK_THAT( 2.22433973930853, WithinRel( linear.y()[10] ) );
+        CHECK_THAT( 2.              , WithinRel( linear.y()[11] ) );
+
+        CHECK( true == linear.isLinearised() );
+      } // THEN
+
+      THEN( "arithmetic operations cannot be performed" ) {
+
+        InterpolationTable< double > result( { 1., 4. }, { 0., 0. } );
+        InterpolationTable< double > right( { 1., 4. }, { 0., 0. } );
+
+        // scalar operations
+        CHECK_THROWS( chunk += 2. );
+        CHECK_THROWS( chunk -= 2. );
+        CHECK_THROWS( chunk *= 2. );
+        CHECK_THROWS( chunk /= 2. );
+        CHECK_THROWS( result = -chunk );
+        CHECK_THROWS( result = chunk + 2. );
+        CHECK_THROWS( result = chunk - 2. );
+        CHECK_THROWS( result = chunk * 2. );
+        CHECK_THROWS( result = chunk / 2. );
+        CHECK_THROWS( result = 2. + chunk );
+        CHECK_THROWS( result = 2. - chunk );
+        CHECK_THROWS( result = 2. * chunk );
+
+        // table operations
+        CHECK_THROWS( chunk += right );
+        CHECK_THROWS( chunk -= right );
+        CHECK_THROWS( result = chunk + right );
+        CHECK_THROWS( result = chunk - right );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+
   GIVEN( "invalid data for an InterpolationTable object" ) {
 
     WHEN( "there are not enough values in the x or y grid" ) {

--- a/src/scion/math/InterpolationTable/test/InterpolationTable.test.cpp
+++ b/src/scion/math/InterpolationTable/test/InterpolationTable.test.cpp
@@ -1698,7 +1698,7 @@ SCENARIO( "InterpolationTable" ) {
 
       const std::vector< double > x = { 1., 2., 2., 3., 4. };
       const std::vector< double > y = { 4., 3., 4., 3., 2. };
-      const std::vector< std::size_t > boundaries = { 2, 4 };
+      const std::vector< std::size_t > boundaries = { 2, 4 }; // <-- pointing to end of the jump
       const std::vector< InterpolationType > interpolants = {
 
         InterpolationType::LinearLinear,
@@ -1733,113 +1733,52 @@ SCENARIO( "InterpolationTable" ) {
 
         CHECK( true == std::holds_alternative< IntervalDomain< double > >( chunk.domain() ) );
       } // THEN
+    } // WHEN
+  } // GIVEN
 
-      THEN( "a InterpolationTable can be evaluated" ) {
+  GIVEN( "non-linearised data with multiple regions with a jump at the end that goes to zero" ) {
 
-        // values of x in the x grid
-        CHECK_THAT( 4., WithinRel( chunk( 1. ) ) );
-        CHECK_THAT( 4., WithinRel( chunk( 2. ) ) );
-        CHECK_THAT( 3., WithinRel( chunk( 3. ) ) );
-        CHECK_THAT( 2., WithinRel( chunk( 4. ) ) );
+    // note: at construction time, the last x and y value will be removed and the last
+    //       boundary value will be decremented by 1.
 
-        // values of x outside the x grid
-        CHECK_THAT( 0., WithinRel( chunk( 0. ) ) );
-        CHECK_THAT( 0., WithinRel( chunk( 5. ) ) );
+    WHEN( "the data is given explicitly" ) {
 
-        // values of x inside the x grid (lin-lin piece)
-        CHECK_THAT( 3.5, WithinRel( chunk( 1.5 ) ) );
+      const std::vector< double > x = { 1., 2., 3., 4., 4. }; // <-- jump at end
+      const std::vector< double > y = { 4., 3., 2., 1., 0. }; // <-- last value is zero
+      const std::vector< std::size_t > boundaries = { 1, 4 }; // <-- pointing to end
+      const std::vector< InterpolationType > interpolants = {
 
-        // values of x inside the x grid (lin-log piece)
-        CHECK_THAT( 3.44966028678679, WithinRel( chunk( 2.5 ) ) );
-        CHECK_THAT( 2.46416306545103, WithinRel( chunk( 3.5 ) ) );
-      } // THEN
+        InterpolationType::LinearLinear,
+        InterpolationType::LinearLog
+      };
 
-      THEN( "the domain can be tested" ) {
+      InterpolationTable< double > chunk( std::move( x ), std::move( y ),
+                                          std::move( boundaries ),
+                                          std::move( interpolants ) );
 
-        CHECK( true == chunk.isInside( 1.0 ) );
-        CHECK( true == chunk.isInside( 2.5 ) );
-        CHECK( true == chunk.isInside( 4.0 ) );
+      THEN( "an InterpolationTable can be constructed and members can be tested" ) {
 
-        CHECK( false == chunk.isContained( 1.0 ) );
-        CHECK( true == chunk.isContained( 2.5 ) );
-        CHECK( false == chunk.isContained( 4.0 ) );
+        CHECK( 4 == chunk.numberPoints() );
+        CHECK( 2 == chunk.numberRegions() );
+        CHECK( 4 == chunk.x().size() );
+        CHECK( 4 == chunk.y().size() );
+        CHECK( 2 == chunk.boundaries().size() );
+        CHECK( 2 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.x()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.x()[1] ) );
+        CHECK_THAT( 3., WithinRel( chunk.x()[2] ) );
+        CHECK_THAT( 4., WithinRel( chunk.x()[3] ) ); // <-- last point removed
+        CHECK_THAT( 4., WithinRel( chunk.y()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.y()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.y()[2] ) );
+        CHECK_THAT( 1., WithinRel( chunk.y()[3] ) ); // <-- last point removed
+        CHECK( 1 == chunk.boundaries()[0] );
+        CHECK( 3 == chunk.boundaries()[1] );         // <-- boundary value reset
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLog == chunk.interpolants()[1] );
+        CHECK( false == chunk.isLinearised() );
 
-        CHECK( true == chunk.isSameDomain( IntervalDomain< double >( 1., 4. ) ) );
-        CHECK( false == chunk.isSameDomain( IntervalDomain< double >( 0., 4. ) ) );
-        CHECK( false == chunk.isSameDomain( OpenDomain< double >() ) );
-      } // THEN
-
-      THEN( "an InterpolationTable can be linearised" ) {
-
-        InterpolationTable< double > linear = chunk.linearise();
-
-        CHECK( 12 == linear.numberPoints() );
-        CHECK( 2 == linear.numberRegions() );
-
-        CHECK( 12 == linear.x().size() );
-        CHECK( 12 == linear.y().size() );
-        CHECK( 2 == linear.boundaries().size() );
-        CHECK( 2 == linear.interpolants().size() );
-
-        CHECK(  1 == linear.boundaries()[0] );
-        CHECK( 11 == linear.boundaries()[1] );
-
-        CHECK( InterpolationType::LinearLinear == linear.interpolants()[0] );
-        CHECK( InterpolationType::LinearLinear == linear.interpolants()[1] );
-
-        CHECK_THAT( 1.   , WithinRel( linear.x()[0] ) );
-        CHECK_THAT( 2.   , WithinRel( linear.x()[1] ) );
-        CHECK_THAT( 2.   , WithinRel( linear.x()[2] ) );
-        CHECK_THAT( 2.125, WithinRel( linear.x()[3] ) );
-        CHECK_THAT( 2.25 , WithinRel( linear.x()[4] ) );
-        CHECK_THAT( 2.5  , WithinRel( linear.x()[5] ) );
-        CHECK_THAT( 2.75 , WithinRel( linear.x()[6] ) );
-        CHECK_THAT( 3.   , WithinRel( linear.x()[7] ) );
-        CHECK_THAT( 3.25 , WithinRel( linear.x()[8] ) );
-        CHECK_THAT( 3.5  , WithinRel( linear.x()[9] ) );
-        CHECK_THAT( 3.75 , WithinRel( linear.x()[10] ) );
-        CHECK_THAT( 4.   , WithinRel( linear.x()[11] ) );
-
-        CHECK_THAT( 4.              , WithinRel( linear.y()[0] ) );
-        CHECK_THAT( 3.              , WithinRel( linear.y()[1] ) );
-        CHECK_THAT( 4.              , WithinRel( linear.y()[2] ) );
-        CHECK_THAT( 3.85048128530886, WithinRel( linear.y()[3] ) );
-        CHECK_THAT( 3.70951129135145, WithinRel( linear.y()[4] ) );
-        CHECK_THAT( 3.44966028678679, WithinRel( linear.y()[5] ) );
-        CHECK_THAT( 3.21459646033567, WithinRel( linear.y()[6] ) );
-        CHECK_THAT( 3.              , WithinRel( linear.y()[7] ) );
-        CHECK_THAT( 2.72176678584324, WithinRel( linear.y()[8] ) );
-        CHECK_THAT( 2.46416306545103, WithinRel( linear.y()[9] ) );
-        CHECK_THAT( 2.22433973930853, WithinRel( linear.y()[10] ) );
-        CHECK_THAT( 2.              , WithinRel( linear.y()[11] ) );
-
-        CHECK( true == linear.isLinearised() );
-      } // THEN
-
-      THEN( "arithmetic operations cannot be performed" ) {
-
-        InterpolationTable< double > result( { 1., 4. }, { 0., 0. } );
-        InterpolationTable< double > right( { 1., 4. }, { 0., 0. } );
-
-        // scalar operations
-        CHECK_THROWS( chunk += 2. );
-        CHECK_THROWS( chunk -= 2. );
-        CHECK_THROWS( chunk *= 2. );
-        CHECK_THROWS( chunk /= 2. );
-        CHECK_THROWS( result = -chunk );
-        CHECK_THROWS( result = chunk + 2. );
-        CHECK_THROWS( result = chunk - 2. );
-        CHECK_THROWS( result = chunk * 2. );
-        CHECK_THROWS( result = chunk / 2. );
-        CHECK_THROWS( result = 2. + chunk );
-        CHECK_THROWS( result = 2. - chunk );
-        CHECK_THROWS( result = 2. * chunk );
-
-        // table operations
-        CHECK_THROWS( chunk += right );
-        CHECK_THROWS( chunk -= right );
-        CHECK_THROWS( result = chunk + right );
-        CHECK_THROWS( result = chunk - right );
+        CHECK( true == std::holds_alternative< IntervalDomain< double > >( chunk.domain() ) );
       } // THEN
     } // WHEN
   } // GIVEN


### PR DESCRIPTION
 In some cases, the boundary values in an InterpolationTable can point to the second point of a jump (quite a few ENDF files do this at the end of the RRR or URR). While this is not an error (we will never interpolate on a jump), we need the boundaries to point to the first point in the jump instead of the second one since an InterpolationTable will internally subdivide into separate interpolation regions (this makes linearisation so much easier). 

When this is encountered, the boundary value is adjusted to point to the first x value in the jump.

When testing endf80 neutron files with dryad, about 100 ENDF files could not be read because of this.
