### PR TITLE
Fix/assignment

### DIFF
--- a/src/scion/math/HistogramTable/src/ctor.hpp
+++ b/src/scion/math/HistogramTable/src/ctor.hpp
@@ -1,3 +1,9 @@
+HistogramTable( const HistogramTable& ) = default;
+HistogramTable( HistogramTable&& ) = default;
+
+HistogramTable& operator=( const HistogramTable& ) = default;
+HistogramTable& operator=( HistogramTable&& ) = default;
+
 /**
  *  @brief Constructor
  *

--- a/src/scion/math/HistogramTableFunction/src/ctor.hpp
+++ b/src/scion/math/HistogramTableFunction/src/ctor.hpp
@@ -1,3 +1,9 @@
+HistogramTableFunction( const HistogramTableFunction& ) = default;
+HistogramTableFunction( HistogramTableFunction&& ) = default;
+
+HistogramTableFunction& operator=( const HistogramTableFunction& ) = default;
+HistogramTableFunction& operator=( HistogramTableFunction&& ) = default;
+
 /**
  *  @brief Constructor
  *

--- a/src/scion/math/InterpolationTable/src/ctor.hpp
+++ b/src/scion/math/InterpolationTable/src/ctor.hpp
@@ -40,7 +40,13 @@ InterpolationTable& operator=( const InterpolationTable& base ) {
 
   if ( this != &base ) {
 
-    new (this) InterpolationTable( base );
+    Parent::operator=( base );
+    this->x_ = base.x_;
+    this->y_ = base.y_;
+    this->boundaries_ = base.boundaries_;
+    this->interpolants_ = base.interpolants_;
+    this->linearised_ = base.linearised_;
+    this->generateTables();
   }
   return *this;
 }
@@ -54,7 +60,13 @@ InterpolationTable& operator=( InterpolationTable&& base ) {
 
   if ( this != &base ) {
 
-    new (this) InterpolationTable( std::move( base ) );
+    Parent::operator=( std::move( base ) );
+    this->x_ = std::move( base.x_ );
+    this->y_ = std::move( base.y_ );
+    this->boundaries_ = std::move( base.boundaries_ );
+    this->interpolants_ = std::move( base.interpolants_ );
+    this->linearised_ = std::move( base.linearised_ );
+    this->generateTables();
   }
   return *this;
 }

--- a/src/scion/math/InterpolationTable/src/ctor.hpp
+++ b/src/scion/math/InterpolationTable/src/ctor.hpp
@@ -65,7 +65,7 @@ InterpolationTable& operator=( InterpolationTable&& base ) {
     this->y_ = std::move( base.y_ );
     this->boundaries_ = std::move( base.boundaries_ );
     this->interpolants_ = std::move( base.interpolants_ );
-    this->linearised_ = std::move( base.linearised_ );
+    this->linearised_ = base.linearised_;
     this->generateTables();
   }
   return *this;

--- a/src/scion/math/InterpolationTable/src/ctor.hpp
+++ b/src/scion/math/InterpolationTable/src/ctor.hpp
@@ -45,7 +45,6 @@ InterpolationTable& operator=( const InterpolationTable& base ) {
     this->y_ = base.y_;
     this->boundaries_ = base.boundaries_;
     this->interpolants_ = base.interpolants_;
-    this->linearised_ = base.linearised_;
     this->generateTables();
   }
   return *this;
@@ -65,7 +64,6 @@ InterpolationTable& operator=( InterpolationTable&& base ) {
     this->y_ = std::move( base.y_ );
     this->boundaries_ = std::move( base.boundaries_ );
     this->interpolants_ = std::move( base.interpolants_ );
-    this->linearised_ = base.linearised_;
     this->generateTables();
   }
   return *this;

--- a/src/scion/math/InterpolationTable/test/InterpolationTable.test.cpp
+++ b/src/scion/math/InterpolationTable/test/InterpolationTable.test.cpp
@@ -51,6 +51,96 @@ SCENARIO( "InterpolationTable" ) {
         CHECK( true == std::holds_alternative< IntervalDomain< double > >( chunk.domain() ) );
       } // THEN
 
+      THEN( "an InterpolationTable can be copy and move constructed" ) {
+
+        InterpolationTable< double > copy( chunk );
+        CHECK( 4 == copy.numberPoints() );
+        CHECK( 1 == copy.numberRegions() );
+        CHECK( 4 == copy.x().size() );
+        CHECK( 4 == copy.y().size() );
+        CHECK( 1 == copy.boundaries().size() );
+        CHECK( 1 == copy.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( copy.x()[0] ) );
+        CHECK_THAT( 2., WithinRel( copy.x()[1] ) );
+        CHECK_THAT( 3., WithinRel( copy.x()[2] ) );
+        CHECK_THAT( 4., WithinRel( copy.x()[3] ) );
+        CHECK_THAT( 4., WithinRel( copy.y()[0] ) );
+        CHECK_THAT( 3., WithinRel( copy.y()[1] ) );
+        CHECK_THAT( 2., WithinRel( copy.y()[2] ) );
+        CHECK_THAT( 1., WithinRel( copy.y()[3] ) );
+        CHECK( 3 == copy.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == copy.interpolants()[0] );
+        CHECK( true == copy.isLinearised() );
+        CHECK( true == std::holds_alternative< IntervalDomain< double > >( copy.domain() ) );
+
+        InterpolationTable< double > move( std::move( copy ) );
+        CHECK( 4 == move.numberPoints() );
+        CHECK( 1 == move.numberRegions() );
+        CHECK( 4 == move.x().size() );
+        CHECK( 4 == move.y().size() );
+        CHECK( 1 == move.boundaries().size() );
+        CHECK( 1 == move.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( move.x()[0] ) );
+        CHECK_THAT( 2., WithinRel( move.x()[1] ) );
+        CHECK_THAT( 3., WithinRel( move.x()[2] ) );
+        CHECK_THAT( 4., WithinRel( move.x()[3] ) );
+        CHECK_THAT( 4., WithinRel( move.y()[0] ) );
+        CHECK_THAT( 3., WithinRel( move.y()[1] ) );
+        CHECK_THAT( 2., WithinRel( move.y()[2] ) );
+        CHECK_THAT( 1., WithinRel( move.y()[3] ) );
+        CHECK( 3 == move.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == move.interpolants()[0] );
+        CHECK( true == move.isLinearised() );
+        CHECK( true == std::holds_alternative< IntervalDomain< double > >( move.domain() ) );
+      } // THEN
+
+      THEN( "an InterpolationTable can be copy and move assigned" ) {
+
+        InterpolationTable< double > copy( { 1., 4. }, { 0., 0. } );
+        copy = chunk;
+
+        CHECK( 4 == copy.numberPoints() );
+        CHECK( 1 == copy.numberRegions() );
+        CHECK( 4 == copy.x().size() );
+        CHECK( 4 == copy.y().size() );
+        CHECK( 1 == copy.boundaries().size() );
+        CHECK( 1 == copy.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( copy.x()[0] ) );
+        CHECK_THAT( 2., WithinRel( copy.x()[1] ) );
+        CHECK_THAT( 3., WithinRel( copy.x()[2] ) );
+        CHECK_THAT( 4., WithinRel( copy.x()[3] ) );
+        CHECK_THAT( 4., WithinRel( copy.y()[0] ) );
+        CHECK_THAT( 3., WithinRel( copy.y()[1] ) );
+        CHECK_THAT( 2., WithinRel( copy.y()[2] ) );
+        CHECK_THAT( 1., WithinRel( copy.y()[3] ) );
+        CHECK( 3 == copy.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == copy.interpolants()[0] );
+        CHECK( true == copy.isLinearised() );
+        CHECK( true == std::holds_alternative< IntervalDomain< double > >( copy.domain() ) );
+
+        InterpolationTable< double > move( { 1., 4. }, { 0., 0. } );
+        move = std::move( copy );
+
+        CHECK( 4 == move.numberPoints() );
+        CHECK( 1 == move.numberRegions() );
+        CHECK( 4 == move.x().size() );
+        CHECK( 4 == move.y().size() );
+        CHECK( 1 == move.boundaries().size() );
+        CHECK( 1 == move.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( move.x()[0] ) );
+        CHECK_THAT( 2., WithinRel( move.x()[1] ) );
+        CHECK_THAT( 3., WithinRel( move.x()[2] ) );
+        CHECK_THAT( 4., WithinRel( move.x()[3] ) );
+        CHECK_THAT( 4., WithinRel( move.y()[0] ) );
+        CHECK_THAT( 3., WithinRel( move.y()[1] ) );
+        CHECK_THAT( 2., WithinRel( move.y()[2] ) );
+        CHECK_THAT( 1., WithinRel( move.y()[3] ) );
+        CHECK( 3 == move.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == move.interpolants()[0] );
+        CHECK( true == move.isLinearised() );
+        CHECK( true == std::holds_alternative< IntervalDomain< double > >( move.domain() ) );
+      } // THEN
+
       THEN( "an InterpolationTable can be evaluated" ) {
 
         // values of x in the x grid

--- a/src/scion/math/InterpolationTableFunction/src/ctor.hpp
+++ b/src/scion/math/InterpolationTableFunction/src/ctor.hpp
@@ -38,7 +38,12 @@ InterpolationTableFunction& operator=( const InterpolationTableFunction& base ) 
 
   if ( this != &base ) {
 
-    new (this) InterpolationTableFunction( base );
+    Parent::operator=( base );
+    this->x_ = base.x_;
+    this->f_ = base.f_;
+    this->boundaries_ = base.boundaries_;
+    this->interpolants_ = base.interpolants_;
+    this->generateTables();
   }
   return *this;
 }
@@ -52,7 +57,12 @@ InterpolationTableFunction& operator=( InterpolationTableFunction&& base ) {
 
   if ( this != &base ) {
 
-    new (this) InterpolationTableFunction( std::move( base ) );
+    Parent::operator=( base );
+    this->x_ = std::move( base.x_ );
+    this->f_ = std::move( base.f_ );
+    this->boundaries_ = std::move( base.boundaries_ );
+    this->interpolants_ = std::move( base.interpolants_ );
+    this->generateTables();
   }
   return *this;
 }

--- a/src/scion/math/InterpolationTableFunction/test/InterpolationTableFunction.test.cpp
+++ b/src/scion/math/InterpolationTableFunction/test/InterpolationTableFunction.test.cpp
@@ -85,6 +85,191 @@ SCENARIO( "InterpolationTableFunction" ) {
         CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
       } // THEN
 
+      THEN( "an InterpolationTableFunction can be copy and move constructed" ) {
+
+        Table2D copy( chunk );
+        CHECK( 4 == copy.numberPoints() );
+        CHECK( 1 == copy.numberRegions() );
+        CHECK( 4 == copy.x().size() );
+        CHECK( 4 == copy.f().size() );
+        CHECK( 1 == copy.boundaries().size() );
+        CHECK( 1 == copy.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( copy.x()[0] ) );
+        CHECK_THAT( 2., WithinRel( copy.x()[1] ) );
+        CHECK_THAT( 3., WithinRel( copy.x()[2] ) );
+        CHECK_THAT( 4., WithinRel( copy.x()[3] ) );
+        CHECK( 2 == copy.f()[0].x().size() );
+        CHECK( 2 == copy.f()[0].y().size() );
+        CHECK( 3 == copy.f()[1].x().size() );
+        CHECK( 3 == copy.f()[1].y().size() );
+        CHECK( 3 == copy.f()[2].x().size() );
+        CHECK( 3 == copy.f()[2].y().size() );
+        CHECK( 2 == copy.f()[3].x().size() );
+        CHECK( 2 == copy.f()[3].y().size() );
+        CHECK_THAT( -1.  , WithinRel( copy.f()[0].x()[0] ) );
+        CHECK_THAT(  1.  , WithinRel( copy.f()[0].x()[1] ) );
+        CHECK_THAT(  0.5 , WithinRel( copy.f()[0].y()[0] ) );
+        CHECK_THAT(  0.5 , WithinRel( copy.f()[0].y()[1] ) );
+        CHECK_THAT( -1.  , WithinRel( copy.f()[1].x()[0] ) );
+        CHECK_THAT(  0.  , WithinRel( copy.f()[1].x()[1] ) );
+        CHECK_THAT(  1.  , WithinRel( copy.f()[1].x()[2] ) );
+        CHECK_THAT(  0.49, WithinRel( copy.f()[1].y()[0] ) );
+        CHECK_THAT(  0.5 , WithinRel( copy.f()[1].y()[1] ) );
+        CHECK_THAT(  0.51, WithinRel( copy.f()[1].y()[2] ) );
+        CHECK_THAT( -1.  , WithinRel( copy.f()[2].x()[0] ) );
+        CHECK_THAT(  0.  , WithinRel( copy.f()[2].x()[1] ) );
+        CHECK_THAT(  1.  , WithinRel( copy.f()[2].x()[2] ) );
+        CHECK_THAT(  0.4 , WithinRel( copy.f()[2].y()[0] ) );
+        CHECK_THAT(  0.5 , WithinRel( copy.f()[2].y()[1] ) );
+        CHECK_THAT(  0.6 , WithinRel( copy.f()[2].y()[2] ) );
+        CHECK_THAT( -1.  , WithinRel( copy.f()[3].x()[0] ) );
+        CHECK_THAT(  1.  , WithinRel( copy.f()[3].x()[1] ) );
+        CHECK_THAT(  0.1 , WithinRel( copy.f()[3].y()[0] ) );
+        CHECK_THAT(  0.9 , WithinRel( copy.f()[3].y()[1] ) );
+        CHECK( 3 == copy.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == copy.interpolants()[0] );
+
+        Table2D move( std::move( copy ) );
+        CHECK( 4 == move.numberPoints() );
+        CHECK( 1 == move.numberRegions() );
+        CHECK( 4 == move.x().size() );
+        CHECK( 4 == move.f().size() );
+        CHECK( 1 == move.boundaries().size() );
+        CHECK( 1 == move.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( move.x()[0] ) );
+        CHECK_THAT( 2., WithinRel( move.x()[1] ) );
+        CHECK_THAT( 3., WithinRel( move.x()[2] ) );
+        CHECK_THAT( 4., WithinRel( move.x()[3] ) );
+        CHECK( 2 == move.f()[0].x().size() );
+        CHECK( 2 == move.f()[0].y().size() );
+        CHECK( 3 == move.f()[1].x().size() );
+        CHECK( 3 == move.f()[1].y().size() );
+        CHECK( 3 == move.f()[2].x().size() );
+        CHECK( 3 == move.f()[2].y().size() );
+        CHECK( 2 == move.f()[3].x().size() );
+        CHECK( 2 == move.f()[3].y().size() );
+        CHECK_THAT( -1.  , WithinRel( move.f()[0].x()[0] ) );
+        CHECK_THAT(  1.  , WithinRel( move.f()[0].x()[1] ) );
+        CHECK_THAT(  0.5 , WithinRel( move.f()[0].y()[0] ) );
+        CHECK_THAT(  0.5 , WithinRel( move.f()[0].y()[1] ) );
+        CHECK_THAT( -1.  , WithinRel( move.f()[1].x()[0] ) );
+        CHECK_THAT(  0.  , WithinRel( move.f()[1].x()[1] ) );
+        CHECK_THAT(  1.  , WithinRel( move.f()[1].x()[2] ) );
+        CHECK_THAT(  0.49, WithinRel( move.f()[1].y()[0] ) );
+        CHECK_THAT(  0.5 , WithinRel( move.f()[1].y()[1] ) );
+        CHECK_THAT(  0.51, WithinRel( move.f()[1].y()[2] ) );
+        CHECK_THAT( -1.  , WithinRel( move.f()[2].x()[0] ) );
+        CHECK_THAT(  0.  , WithinRel( move.f()[2].x()[1] ) );
+        CHECK_THAT(  1.  , WithinRel( move.f()[2].x()[2] ) );
+        CHECK_THAT(  0.4 , WithinRel( move.f()[2].y()[0] ) );
+        CHECK_THAT(  0.5 , WithinRel( move.f()[2].y()[1] ) );
+        CHECK_THAT(  0.6 , WithinRel( move.f()[2].y()[2] ) );
+        CHECK_THAT( -1.  , WithinRel( move.f()[3].x()[0] ) );
+        CHECK_THAT(  1.  , WithinRel( move.f()[3].x()[1] ) );
+        CHECK_THAT(  0.1 , WithinRel( move.f()[3].y()[0] ) );
+        CHECK_THAT(  0.9 , WithinRel( move.f()[3].y()[1] ) );
+        CHECK( 3 == move.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == move.interpolants()[0] );
+      } // THEN
+
+      THEN( "an InterpolationTableFunction can be copy and move assigned" ) {
+
+        const std::vector< double > x = { 0., 1. };
+        const std::vector< InterpolationTable< double > > f = {
+
+          { { -1., +1. }, { 0.5, 0.5 } },
+          { { -1., +1. }, { 0.1, 0.9 } }
+        };
+
+        Table2D copy( x, f );
+        copy = chunk;
+
+        CHECK( 4 == copy.numberPoints() );
+        CHECK( 1 == copy.numberRegions() );
+        CHECK( 4 == copy.x().size() );
+        CHECK( 4 == copy.f().size() );
+        CHECK( 1 == copy.boundaries().size() );
+        CHECK( 1 == copy.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( copy.x()[0] ) );
+        CHECK_THAT( 2., WithinRel( copy.x()[1] ) );
+        CHECK_THAT( 3., WithinRel( copy.x()[2] ) );
+        CHECK_THAT( 4., WithinRel( copy.x()[3] ) );
+        CHECK( 2 == copy.f()[0].x().size() );
+        CHECK( 2 == copy.f()[0].y().size() );
+        CHECK( 3 == copy.f()[1].x().size() );
+        CHECK( 3 == copy.f()[1].y().size() );
+        CHECK( 3 == copy.f()[2].x().size() );
+        CHECK( 3 == copy.f()[2].y().size() );
+        CHECK( 2 == copy.f()[3].x().size() );
+        CHECK( 2 == copy.f()[3].y().size() );
+        CHECK_THAT( -1.  , WithinRel( copy.f()[0].x()[0] ) );
+        CHECK_THAT(  1.  , WithinRel( copy.f()[0].x()[1] ) );
+        CHECK_THAT(  0.5 , WithinRel( copy.f()[0].y()[0] ) );
+        CHECK_THAT(  0.5 , WithinRel( copy.f()[0].y()[1] ) );
+        CHECK_THAT( -1.  , WithinRel( copy.f()[1].x()[0] ) );
+        CHECK_THAT(  0.  , WithinRel( copy.f()[1].x()[1] ) );
+        CHECK_THAT(  1.  , WithinRel( copy.f()[1].x()[2] ) );
+        CHECK_THAT(  0.49, WithinRel( copy.f()[1].y()[0] ) );
+        CHECK_THAT(  0.5 , WithinRel( copy.f()[1].y()[1] ) );
+        CHECK_THAT(  0.51, WithinRel( copy.f()[1].y()[2] ) );
+        CHECK_THAT( -1.  , WithinRel( copy.f()[2].x()[0] ) );
+        CHECK_THAT(  0.  , WithinRel( copy.f()[2].x()[1] ) );
+        CHECK_THAT(  1.  , WithinRel( copy.f()[2].x()[2] ) );
+        CHECK_THAT(  0.4 , WithinRel( copy.f()[2].y()[0] ) );
+        CHECK_THAT(  0.5 , WithinRel( copy.f()[2].y()[1] ) );
+        CHECK_THAT(  0.6 , WithinRel( copy.f()[2].y()[2] ) );
+        CHECK_THAT( -1.  , WithinRel( copy.f()[3].x()[0] ) );
+        CHECK_THAT(  1.  , WithinRel( copy.f()[3].x()[1] ) );
+        CHECK_THAT(  0.1 , WithinRel( copy.f()[3].y()[0] ) );
+        CHECK_THAT(  0.9 , WithinRel( copy.f()[3].y()[1] ) );
+        CHECK( 3 == copy.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == copy.interpolants()[0] );
+
+        Table2D move( x, f );
+        move = std::move( copy );
+
+        CHECK( 4 == move.numberPoints() );
+        CHECK( 1 == move.numberRegions() );
+        CHECK( 4 == move.x().size() );
+        CHECK( 4 == move.f().size() );
+        CHECK( 1 == move.boundaries().size() );
+        CHECK( 1 == move.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( move.x()[0] ) );
+        CHECK_THAT( 2., WithinRel( move.x()[1] ) );
+        CHECK_THAT( 3., WithinRel( move.x()[2] ) );
+        CHECK_THAT( 4., WithinRel( move.x()[3] ) );
+        CHECK( 2 == move.f()[0].x().size() );
+        CHECK( 2 == move.f()[0].y().size() );
+        CHECK( 3 == move.f()[1].x().size() );
+        CHECK( 3 == move.f()[1].y().size() );
+        CHECK( 3 == move.f()[2].x().size() );
+        CHECK( 3 == move.f()[2].y().size() );
+        CHECK( 2 == move.f()[3].x().size() );
+        CHECK( 2 == move.f()[3].y().size() );
+        CHECK_THAT( -1.  , WithinRel( move.f()[0].x()[0] ) );
+        CHECK_THAT(  1.  , WithinRel( move.f()[0].x()[1] ) );
+        CHECK_THAT(  0.5 , WithinRel( move.f()[0].y()[0] ) );
+        CHECK_THAT(  0.5 , WithinRel( move.f()[0].y()[1] ) );
+        CHECK_THAT( -1.  , WithinRel( move.f()[1].x()[0] ) );
+        CHECK_THAT(  0.  , WithinRel( move.f()[1].x()[1] ) );
+        CHECK_THAT(  1.  , WithinRel( move.f()[1].x()[2] ) );
+        CHECK_THAT(  0.49, WithinRel( move.f()[1].y()[0] ) );
+        CHECK_THAT(  0.5 , WithinRel( move.f()[1].y()[1] ) );
+        CHECK_THAT(  0.51, WithinRel( move.f()[1].y()[2] ) );
+        CHECK_THAT( -1.  , WithinRel( move.f()[2].x()[0] ) );
+        CHECK_THAT(  0.  , WithinRel( move.f()[2].x()[1] ) );
+        CHECK_THAT(  1.  , WithinRel( move.f()[2].x()[2] ) );
+        CHECK_THAT(  0.4 , WithinRel( move.f()[2].y()[0] ) );
+        CHECK_THAT(  0.5 , WithinRel( move.f()[2].y()[1] ) );
+        CHECK_THAT(  0.6 , WithinRel( move.f()[2].y()[2] ) );
+        CHECK_THAT( -1.  , WithinRel( move.f()[3].x()[0] ) );
+        CHECK_THAT(  1.  , WithinRel( move.f()[3].x()[1] ) );
+        CHECK_THAT(  0.1 , WithinRel( move.f()[3].y()[0] ) );
+        CHECK_THAT(  0.9 , WithinRel( move.f()[3].y()[1] ) );
+        CHECK( 3 == move.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == move.interpolants()[0] );
+      } // THEN
+
       THEN( "an InterpolationTableFunction can be evaluated" ) {
 
         // values of x in the x grid

--- a/src/scion/math/IntervalDomain/src/ctor.hpp
+++ b/src/scion/math/IntervalDomain/src/ctor.hpp
@@ -3,6 +3,12 @@
  */
 IntervalDomain() = default;
 
+IntervalDomain( const IntervalDomain& ) = default;
+IntervalDomain( IntervalDomain&& ) = default;
+
+IntervalDomain& operator=( const IntervalDomain& ) = default;
+IntervalDomain& operator=( IntervalDomain&& ) = default;
+
 /**
  *  @brief Constructor
  *

--- a/src/scion/math/LinearLinearTable/src/ctor.hpp
+++ b/src/scion/math/LinearLinearTable/src/ctor.hpp
@@ -1,3 +1,9 @@
+LinearLinearTable( const LinearLinearTable& ) = default;
+LinearLinearTable( LinearLinearTable&& ) = default;
+
+LinearLinearTable& operator=( const LinearLinearTable& ) = default;
+LinearLinearTable& operator=( LinearLinearTable&& ) = default;
+
 /**
  *  @brief Constructor
  *

--- a/src/scion/math/LinearLinearTableFunction/src/ctor.hpp
+++ b/src/scion/math/LinearLinearTableFunction/src/ctor.hpp
@@ -1,3 +1,9 @@
+LinearLinearTableFunction( const LinearLinearTableFunction& ) = default;
+LinearLinearTableFunction( LinearLinearTableFunction&& ) = default;
+
+LinearLinearTableFunction& operator=( const LinearLinearTableFunction& ) = default;
+LinearLinearTableFunction& operator=( LinearLinearTableFunction&& ) = default;
+
 /**
  *  @brief Constructor
  *

--- a/src/scion/math/LinearLogTable/src/ctor.hpp
+++ b/src/scion/math/LinearLogTable/src/ctor.hpp
@@ -1,3 +1,9 @@
+LinearLogTable( const LinearLogTable& ) = default;
+LinearLogTable( LinearLogTable&& ) = default;
+
+LinearLogTable& operator=( const LinearLogTable& ) = default;
+LinearLogTable& operator=( LinearLogTable&& ) = default;
+
 /**
  *  @brief Constructor
  *

--- a/src/scion/math/LinearLogTableFunction/src/ctor.hpp
+++ b/src/scion/math/LinearLogTableFunction/src/ctor.hpp
@@ -1,3 +1,9 @@
+LinearLogTableFunction( const LinearLogTableFunction& ) = default;
+LinearLogTableFunction( LinearLogTableFunction&& ) = default;
+
+LinearLogTableFunction& operator=( const LinearLogTableFunction& ) = default;
+LinearLogTableFunction& operator=( LinearLogTableFunction&& ) = default;
+
 /**
  *  @brief Constructor
  *

--- a/src/scion/math/LogLinearTable/src/ctor.hpp
+++ b/src/scion/math/LogLinearTable/src/ctor.hpp
@@ -1,3 +1,9 @@
+LogLinearTable( const LogLinearTable& ) = default;
+LogLinearTable( LogLinearTable&& ) = default;
+
+LogLinearTable& operator=( const LogLinearTable& ) = default;
+LogLinearTable& operator=( LogLinearTable&& ) = default;
+
 /**
  *  @brief Constructor
  *

--- a/src/scion/math/LogLinearTableFunction/src/ctor.hpp
+++ b/src/scion/math/LogLinearTableFunction/src/ctor.hpp
@@ -1,3 +1,9 @@
+LogLinearTableFunction( const LogLinearTableFunction& ) = default;
+LogLinearTableFunction( LogLinearTableFunction&& ) = default;
+
+LogLinearTableFunction& operator=( const LogLinearTableFunction& ) = default;
+LogLinearTableFunction& operator=( LogLinearTableFunction&& ) = default;
+
 /**
  *  @brief Constructor
  *

--- a/src/scion/math/LogLogTable/src/ctor.hpp
+++ b/src/scion/math/LogLogTable/src/ctor.hpp
@@ -1,3 +1,9 @@
+LogLogTable( const LogLogTable& ) = default;
+LogLogTable( LogLogTable&& ) = default;
+
+LogLogTable& operator=( const LogLogTable& ) = default;
+LogLogTable& operator=( LogLogTable&& ) = default;
+
 /**
  *  @brief Constructor
  *

--- a/src/scion/math/LogLogTableFunction/src/ctor.hpp
+++ b/src/scion/math/LogLogTableFunction/src/ctor.hpp
@@ -1,3 +1,9 @@
+LogLogTableFunction( const LogLogTableFunction& ) = default;
+LogLogTableFunction( LogLogTableFunction&& ) = default;
+
+LogLogTableFunction& operator=( const LogLogTableFunction& ) = default;
+LogLogTableFunction& operator=( LogLogTableFunction&& ) = default;
+
 /**
  *  @brief Constructor
  *

--- a/src/scion/math/OneDimensionalFunctionBase.hpp
+++ b/src/scion/math/OneDimensionalFunctionBase.hpp
@@ -54,6 +54,12 @@ namespace math {
     OneDimensionalFunctionBase( DomainVariant domain ) :
       domain_( std::move( domain ) ) {}
 
+    OneDimensionalFunctionBase( const OneDimensionalFunctionBase& ) = default;
+    OneDimensionalFunctionBase( OneDimensionalFunctionBase&& ) = default;
+
+    OneDimensionalFunctionBase& operator=( const OneDimensionalFunctionBase& ) = default;
+    OneDimensionalFunctionBase& operator=( OneDimensionalFunctionBase&& ) = default;
+
   public:
 
     /* methods */

--- a/src/scion/math/OpenDomain.hpp
+++ b/src/scion/math/OpenDomain.hpp
@@ -29,6 +29,12 @@ namespace math {
     /* constructor */
     OpenDomain() = default;
 
+    OpenDomain( const OpenDomain& ) = default;
+    OpenDomain( OpenDomain&& ) = default;
+
+    OpenDomain& operator=( const OpenDomain& ) = default;
+    OpenDomain& operator=( OpenDomain&& ) = default;
+
     /* methods */
 
     /**

--- a/src/scion/math/SingleTableBase/src/ctor.hpp
+++ b/src/scion/math/SingleTableBase/src/ctor.hpp
@@ -4,7 +4,7 @@ private:
  *  @brief Private constructor
  */
 SingleTableBase( IntervalDomain< X >&& domain, XContainer&& x, YContainer&& y ) :
-  Parent( std::move( domain ) ), interpolator_(), 
+  Parent( std::move( domain ) ), interpolator_(),
   x_( std::move( x ) ), y_( std::move( y ) ) {}
 
 protected:
@@ -19,3 +19,8 @@ SingleTableBase( XContainer x, YContainer y ) :
   SingleTableBase( verifyTableAndRetrieveDomain( x, y ),
                    std::move( x ), std::move( y ) ) {}
 
+SingleTableBase( const SingleTableBase& ) = default;
+SingleTableBase( SingleTableBase&& ) = default;
+
+SingleTableBase& operator=( const SingleTableBase& ) = default;
+SingleTableBase& operator=( SingleTableBase&& ) = default;


### PR DESCRIPTION
This replaces placement new in the copy and assignment operators because of memory leaks. Tests for copy and move constructors and assignment operators have been added as well.

As far as I know, no more placement new is present in the entire library.